### PR TITLE
Add concurrency checks for database operations

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     if: |

--- a/plugins/browser-automation-test-recorder/.github/workflows/ci.yml
+++ b/plugins/browser-automation-test-recorder/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test Suite


### PR DESCRIPTION
Added concurrency controls to prevent multiple workflow runs from interfering with each other:

- claude.yml: Prevent concurrent Claude runs on the same issue/PR
- claude-code-review.yml: Cancel outdated reviews when new commits are pushed
- browser-automation-test-recorder CI: Prevent concurrent CI runs on the same branch

This improves workflow efficiency by canceling redundant runs and preventing resource conflicts.