### PR TITLE
refactor(render-waste-detector): Align with TanStack DevTools patterns

### DIFF
--- a/plugins/render-waste-detector/src/__tests__/components/PluginPanel.test.tsx
+++ b/plugins/render-waste-detector/src/__tests__/components/PluginPanel.test.tsx
@@ -158,8 +158,8 @@ const mockEventClient = {
 };
 
 vi.mock('../../core/devtools-client', () => ({
-  getRenderWasteDetectorEventClient: vi.fn(() => mockEventClient),
-  createRenderWasteDetectorEventClient: vi.fn(() => mockEventClient)
+  getRenderWasteDetectorDevToolsClient: vi.fn(() => mockEventClient),
+  createRenderWasteDetectorDevToolsClient: vi.fn(() => mockEventClient)
 }));
 
 describe('PluginPanel', () => {

--- a/plugins/render-waste-detector/src/__tests__/index.test.ts
+++ b/plugins/render-waste-detector/src/__tests__/index.test.ts
@@ -10,9 +10,9 @@ describe('render-waste-detector exports', () => {
   it('should export core functionality', () => {
     expect(exports.useRenderWasteDetectorStore).toBeDefined();
     expect(exports.getRenderWasteDetectorStore).toBeDefined();
-    expect(exports.createRenderWasteDetectorEventClient).toBeDefined();
-    expect(exports.getRenderWasteDetectorEventClient).toBeDefined();
-    expect(exports.resetRenderWasteDetectorEventClient).toBeDefined();
+    expect(exports.createRenderWasteDetectorDevToolsClient).toBeDefined();
+    expect(exports.getRenderWasteDetectorDevToolsClient).toBeDefined();
+    expect(exports.resetRenderWasteDetectorDevToolsClient).toBeDefined();
     expect(exports.getProfilerIntegration).toBeDefined();
     expect(exports.startRenderProfiling).toBeDefined();
     expect(exports.stopRenderProfiling).toBeDefined();
@@ -22,9 +22,9 @@ describe('render-waste-detector exports', () => {
   it('should have proper function types for exported functions', () => {
     expect(typeof exports.useRenderWasteDetectorStore).toBe('function');
     expect(typeof exports.getRenderWasteDetectorStore).toBe('function');
-    expect(typeof exports.createRenderWasteDetectorEventClient).toBe('function');
-    expect(typeof exports.getRenderWasteDetectorEventClient).toBe('function');
-    expect(typeof exports.resetRenderWasteDetectorEventClient).toBe('function');
+    expect(typeof exports.createRenderWasteDetectorDevToolsClient).toBe('function');
+    expect(typeof exports.getRenderWasteDetectorDevToolsClient).toBe('function');
+    expect(typeof exports.resetRenderWasteDetectorDevToolsClient).toBe('function');
     expect(typeof exports.getProfilerIntegration).toBe('function');
     expect(typeof exports.startRenderProfiling).toBe('function');
     expect(typeof exports.stopRenderProfiling).toBe('function');

--- a/plugins/render-waste-detector/src/components/PluginPanel.tsx
+++ b/plugins/render-waste-detector/src/components/PluginPanel.tsx
@@ -34,12 +34,11 @@ import type {
   RenderWasteDetectorPanelProps,
   DevToolsTab,
   RenderWasteDetectorState,
-  RenderWasteDetectorAction,
   OptimizationSuggestion,
 } from "../types";
 import {
-  createRenderWasteDetectorEventClient,
-  getRenderWasteDetectorEventClient,
+  createRenderWasteDetectorDevToolsClient,
+  getRenderWasteDetectorDevToolsClient,
 } from "../core";
 
 // Tab Components
@@ -69,8 +68,8 @@ function PluginPanelInner({
   // Create or get event client
   const eventClient = (() => {
     const client =
-      getRenderWasteDetectorEventClient() ||
-      createRenderWasteDetectorEventClient();
+      getRenderWasteDetectorDevToolsClient() ||
+      createRenderWasteDetectorDevToolsClient();
 
     // Apply default settings if provided
     if (defaultSettings) {
@@ -91,12 +90,6 @@ function PluginPanelInner({
   const handleTabChange = (tab: DevToolsTab) => {
     eventClient.selectTab(tab);
     onTabChange?.(tab);
-  };
-
-  // Handle events
-  const handleEvent = (action: RenderWasteDetectorAction) => {
-    eventClient.dispatch(action);
-    onEvent?.(action);
   };
 
   // Handle component selection
@@ -277,7 +270,6 @@ function PluginPanelInner({
           <OverviewTab
             state={state}
             eventClient={eventClient}
-            dispatch={handleEvent}
             compact={compact}
             onComponentSelect={handleComponentSelect}
             onSuggestionApply={handleSuggestionApply}
@@ -287,7 +279,6 @@ function PluginPanelInner({
           <ComponentsTab
             state={state}
             eventClient={eventClient}
-            dispatch={handleEvent}
             compact={compact}
             onComponentSelect={handleComponentSelect}
             onSuggestionApply={handleSuggestionApply}
@@ -297,7 +288,6 @@ function PluginPanelInner({
           <HeatMapTab
             state={state}
             eventClient={eventClient}
-            dispatch={handleEvent}
             compact={compact}
             onComponentSelect={handleComponentSelect}
             onSuggestionApply={handleSuggestionApply}
@@ -307,7 +297,6 @@ function PluginPanelInner({
           <SuggestionsTab
             state={state}
             eventClient={eventClient}
-            dispatch={handleEvent}
             compact={compact}
             onComponentSelect={handleComponentSelect}
             onSuggestionApply={handleSuggestionApply}
@@ -317,7 +306,6 @@ function PluginPanelInner({
           <TimelineTab
             state={state}
             eventClient={eventClient}
-            dispatch={handleEvent}
             compact={compact}
             onComponentSelect={handleComponentSelect}
             onSuggestionApply={handleSuggestionApply}
@@ -327,7 +315,6 @@ function PluginPanelInner({
           <SettingsTab
             state={state}
             eventClient={eventClient}
-            dispatch={handleEvent}
             compact={compact}
             onComponentSelect={handleComponentSelect}
             onSuggestionApply={handleSuggestionApply}

--- a/plugins/render-waste-detector/src/components/tabs/ComponentsTab.tsx
+++ b/plugins/render-waste-detector/src/components/tabs/ComponentsTab.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import { Search, BarChart3, Filter } from "lucide-react";
 import type {
   RenderWasteDetectorState,
-  RenderWasteDetectorEventClient,
+  RenderWasteDetectorDevToolsClient,
 } from "../../types";
 
 interface ComponentsTabProps {
   state: RenderWasteDetectorState;
-  eventClient: RenderWasteDetectorEventClient;
-  dispatch: (action: unknown) => void;
+  eventClient: RenderWasteDetectorDevToolsClient;
   compact: boolean;
   onComponentSelect: (componentId: string | null) => void;
   onSuggestionApply: (suggestionId: string) => void;
@@ -17,7 +16,6 @@ interface ComponentsTabProps {
 export function ComponentsTab({
   state,
   eventClient,
-  dispatch: _dispatch,
   compact: _compact,
   onComponentSelect,
 }: ComponentsTabProps) {

--- a/plugins/render-waste-detector/src/components/tabs/HeatMapTab.tsx
+++ b/plugins/render-waste-detector/src/components/tabs/HeatMapTab.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import { Flame, Settings, RefreshCw } from "lucide-react";
 import type {
   RenderWasteDetectorState,
-  RenderWasteDetectorEventClient,
+  RenderWasteDetectorDevToolsClient,
 } from "../../types";
 
 interface HeatMapTabProps {
   state: RenderWasteDetectorState;
-  eventClient: RenderWasteDetectorEventClient;
-  dispatch: (action: unknown) => void;
+  eventClient: RenderWasteDetectorDevToolsClient;
   compact: boolean;
   onComponentSelect: (componentId: string | null) => void;
   onSuggestionApply: (suggestionId: string) => void;
@@ -17,7 +16,6 @@ interface HeatMapTabProps {
 export function HeatMapTab({
   state,
   eventClient,
-  dispatch: _dispatch,
   compact: _compact,
   onComponentSelect,
 }: HeatMapTabProps) {

--- a/plugins/render-waste-detector/src/components/tabs/OverviewTab.tsx
+++ b/plugins/render-waste-detector/src/components/tabs/OverviewTab.tsx
@@ -11,13 +11,12 @@ import {
 
 import type {
   RenderWasteDetectorState,
-  RenderWasteDetectorEventClient,
+  RenderWasteDetectorDevToolsClient,
 } from "../../types";
 
 interface OverviewTabProps {
   state: RenderWasteDetectorState;
-  eventClient: RenderWasteDetectorEventClient;
-  dispatch: (action: unknown) => void;
+  eventClient: RenderWasteDetectorDevToolsClient;
   compact: boolean;
   onComponentSelect: (componentId: string | null) => void;
   onSuggestionApply: (suggestionId: string) => void;
@@ -26,7 +25,6 @@ interface OverviewTabProps {
 export function OverviewTab({
   state,
   eventClient,
-  dispatch: _dispatch,
   compact: _compact,
   onComponentSelect,
   onSuggestionApply,

--- a/plugins/render-waste-detector/src/components/tabs/SettingsTab.tsx
+++ b/plugins/render-waste-detector/src/components/tabs/SettingsTab.tsx
@@ -2,14 +2,13 @@ import React from "react";
 import { Download, Upload, RotateCcw } from "lucide-react";
 import type {
   RenderWasteDetectorState,
-  RenderWasteDetectorEventClient,
+  RenderWasteDetectorDevToolsClient,
   DevToolsTab,
 } from "../../types";
 
 interface SettingsTabProps {
   state: RenderWasteDetectorState;
-  eventClient: RenderWasteDetectorEventClient;
-  dispatch: (action: unknown) => void;
+  eventClient: RenderWasteDetectorDevToolsClient;
   compact: boolean;
   onComponentSelect: (componentId: string | null) => void;
   onSuggestionApply: (suggestionId: string) => void;
@@ -18,7 +17,6 @@ interface SettingsTabProps {
 export function SettingsTab({
   state,
   eventClient,
-  dispatch: _dispatch,
   compact: _compact,
 }: SettingsTabProps) {
   const { settings, ui } = state;

--- a/plugins/render-waste-detector/src/components/tabs/SuggestionsTab.tsx
+++ b/plugins/render-waste-detector/src/components/tabs/SuggestionsTab.tsx
@@ -3,14 +3,13 @@ import { Lightbulb, Filter, CheckCircle, X } from "lucide-react";
 import { clsx } from "clsx";
 import type {
   RenderWasteDetectorState,
-  RenderWasteDetectorEventClient,
+  RenderWasteDetectorDevToolsClient,
   OptimizationSuggestion,
 } from "../../types";
 
 interface SuggestionsTabProps {
   state: RenderWasteDetectorState;
-  eventClient: RenderWasteDetectorEventClient;
-  dispatch: (action: unknown) => void;
+  eventClient: RenderWasteDetectorDevToolsClient;
   compact: boolean;
   onComponentSelect: (componentId: string | null) => void;
   onSuggestionApply: (suggestionId: string) => void;
@@ -19,7 +18,6 @@ interface SuggestionsTabProps {
 export function SuggestionsTab({
   state,
   eventClient,
-  dispatch: _dispatch,
   compact: _compact,
   onComponentSelect,
   onSuggestionApply,

--- a/plugins/render-waste-detector/src/components/tabs/TimelineTab.tsx
+++ b/plugins/render-waste-detector/src/components/tabs/TimelineTab.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import { Clock, Play, Pause, ZoomIn, ZoomOut } from "lucide-react";
 import type {
   RenderWasteDetectorState,
-  RenderWasteDetectorEventClient,
+  RenderWasteDetectorDevToolsClient,
 } from "../../types";
 
 interface TimelineTabProps {
   state: RenderWasteDetectorState;
-  eventClient: RenderWasteDetectorEventClient;
-  dispatch: (action: unknown) => void;
+  eventClient: RenderWasteDetectorDevToolsClient;
   compact: boolean;
   onComponentSelect: (componentId: string | null) => void;
   onSuggestionApply: (suggestionId: string) => void;
@@ -17,7 +16,6 @@ interface TimelineTabProps {
 export function TimelineTab({
   state,
   eventClient: _eventClient,
-  dispatch: _dispatch,
   compact: _compact,
   onComponentSelect,
 }: TimelineTabProps) {

--- a/plugins/render-waste-detector/src/core/devtools-store.ts
+++ b/plugins/render-waste-detector/src/core/devtools-store.ts
@@ -667,9 +667,41 @@ export const useRenderWasteDetectorStore = create<RenderWasteDetectorStore>()(
      */
     startRecording: (settings?: Partial<RecordingSettings>) => {
       get().dispatch({ type: "recording/start", payload: settings });
+
+      // Start profiler integration if in browser environment
+      if (typeof window !== 'undefined') {
+        // Import dynamically to avoid circular dependencies
+        Promise.all([
+          import('./profiler-integration'),
+          import('./devtools-client')
+        ]).then(([profiler, client]) => {
+          const eventClient = client.getRenderWasteDetectorDevToolsClient();
+          if (eventClient) {
+            profiler.startRenderProfiling(eventClient);
+          }
+        }).catch((error) => {
+          console.warn('Failed to start profiler integration:', error);
+        });
+      }
     },
 
     stopRecording: () => {
+      // Stop profiler integration if in browser environment
+      if (typeof window !== 'undefined') {
+        // Import dynamically to avoid circular dependencies
+        Promise.all([
+          import('./profiler-integration'),
+          import('./devtools-client')
+        ]).then(([profiler, client]) => {
+          const eventClient = client.getRenderWasteDetectorDevToolsClient();
+          if (eventClient) {
+            profiler.stopRenderProfiling(eventClient);
+          }
+        }).catch((error) => {
+          console.warn('Failed to stop profiler integration:', error);
+        });
+      }
+
       get().dispatch({ type: "recording/stop" });
     },
 

--- a/plugins/render-waste-detector/src/core/profiler-integration.ts
+++ b/plugins/render-waste-detector/src/core/profiler-integration.ts
@@ -6,13 +6,13 @@ import type {
   ContextChange,
   RenderReason,
 } from "../types";
-import type { RenderWasteDetectorEventClient } from "./devtools-client";
+import type { RenderWasteDetectorDevToolsClient } from "./devtools-client";
 
 /**
  * React Profiler integration for render tracking
  */
 export class ProfilerIntegration {
-  private eventClient: RenderWasteDetectorEventClient;
+  private eventClient: RenderWasteDetectorDevToolsClient;
   private componentRegistry = new Map<string, ComponentInfo>();
   private previousProps = new Map<string, any>();
   private previousState = new Map<string, any>();
@@ -20,7 +20,7 @@ export class ProfilerIntegration {
   private renderCounts = new Map<string, number>();
   private isActive = false;
 
-  constructor(eventClient: RenderWasteDetectorEventClient) {
+  constructor(eventClient: RenderWasteDetectorDevToolsClient) {
     this.eventClient = eventClient;
   }
 
@@ -599,7 +599,7 @@ let profilerInstance: ProfilerIntegration | null = null;
 /**
  * Get or create profiler integration instance
  */
-export function getProfilerIntegration(eventClient: RenderWasteDetectorEventClient): ProfilerIntegration {
+export function getProfilerIntegration(eventClient: RenderWasteDetectorDevToolsClient): ProfilerIntegration {
   if (!profilerInstance) {
     profilerInstance = new ProfilerIntegration(eventClient);
   }
@@ -609,13 +609,13 @@ export function getProfilerIntegration(eventClient: RenderWasteDetectorEventClie
 /**
  * Start render profiling
  */
-export function startRenderProfiling(eventClient: RenderWasteDetectorEventClient): void {
+export function startRenderProfiling(eventClient: RenderWasteDetectorDevToolsClient): void {
   getProfilerIntegration(eventClient).start();
 }
 
 /**
  * Stop render profiling
  */
-export function stopRenderProfiling(eventClient: RenderWasteDetectorEventClient): void {
+export function stopRenderProfiling(eventClient: RenderWasteDetectorDevToolsClient): void {
   getProfilerIntegration(eventClient).stop();
 }

--- a/plugins/render-waste-detector/src/hooks/useRenderWasteDetector.ts
+++ b/plugins/render-waste-detector/src/hooks/useRenderWasteDetector.ts
@@ -8,8 +8,8 @@ import type {
   RenderWasteDetectorEvents,
 } from "../types";
 import {
-  createRenderWasteDetectorEventClient,
-  getRenderWasteDetectorEventClient,
+  createRenderWasteDetectorDevToolsClient,
+  getRenderWasteDetectorDevToolsClient,
 } from "../core";
 
 /**
@@ -23,8 +23,8 @@ export function useRenderWasteDetector(
   // Create or get event client
   const eventClient = (React as any).useMemo(() => {
     const client =
-      getRenderWasteDetectorEventClient() ||
-      createRenderWasteDetectorEventClient();
+      getRenderWasteDetectorDevToolsClient() ||
+      createRenderWasteDetectorDevToolsClient();
 
     // Apply settings if provided
     if (settings) {

--- a/plugins/render-waste-detector/src/index.test.ts
+++ b/plugins/render-waste-detector/src/index.test.ts
@@ -15,9 +15,9 @@ describe('Render Waste Detector Plugin - Main Exports', () => {
   it('should export core functionality', () => {
     expect(RenderWasteDetectorPlugin.useRenderWasteDetectorStore).toBeDefined();
     expect(RenderWasteDetectorPlugin.getRenderWasteDetectorStore).toBeDefined();
-    expect(RenderWasteDetectorPlugin.createRenderWasteDetectorEventClient).toBeDefined();
-    expect(RenderWasteDetectorPlugin.getRenderWasteDetectorEventClient).toBeDefined();
-    expect(RenderWasteDetectorPlugin.resetRenderWasteDetectorEventClient).toBeDefined();
+    expect(RenderWasteDetectorPlugin.createRenderWasteDetectorDevToolsClient).toBeDefined();
+    expect(RenderWasteDetectorPlugin.getRenderWasteDetectorDevToolsClient).toBeDefined();
+    expect(RenderWasteDetectorPlugin.resetRenderWasteDetectorDevToolsClient).toBeDefined();
     expect(RenderWasteDetectorPlugin.getProfilerIntegration).toBeDefined();
     expect(RenderWasteDetectorPlugin.startRenderProfiling).toBeDefined();
     expect(RenderWasteDetectorPlugin.stopRenderProfiling).toBeDefined();

--- a/plugins/render-waste-detector/src/index.ts
+++ b/plugins/render-waste-detector/src/index.ts
@@ -5,9 +5,9 @@ export { default as RenderWasteDetectorPanel } from "./components/PluginPanel";
 export {
   useRenderWasteDetectorStore,
   getRenderWasteDetectorStore,
-  createRenderWasteDetectorEventClient,
-  getRenderWasteDetectorEventClient,
-  resetRenderWasteDetectorEventClient,
+  createRenderWasteDetectorDevToolsClient,
+  getRenderWasteDetectorDevToolsClient,
+  resetRenderWasteDetectorDevToolsClient,
   getProfilerIntegration,
   startRenderProfiling,
   stopRenderProfiling,

--- a/plugins/render-waste-detector/src/types/index.ts
+++ b/plugins/render-waste-detector/src/types/index.ts
@@ -3,5 +3,5 @@ export * from "./render-waste";
 export * from "./devtools";
 // Note: global.d.ts contains ambient declarations and doesn't need to be exported
 
-// Add missing event client type
-export type { RenderWasteDetectorEventClient } from "../core/devtools-client";
+// Export event client type
+export type { RenderWasteDetectorDevToolsClient } from "../core/devtools-client";


### PR DESCRIPTION
Major refactoring to follow the standardized TanStack DevTools patterns as seen in error-boundary-visualizer and other plugins.

Changes:
- Simplified RenderWasteDetectorDevToolsClient to follow delegation pattern
- Removed complex event emission logic (emit method and subscribers)
- Removed profiler integration from event client (moved to store)
- Event client now simply delegates to store methods
- Removed unused dispatch method and RenderWasteDetectorAction handling
- Removed dispatch prop from all tab components (unused)
- Updated all type references from RenderWasteDetectorEventClient to RenderWasteDetectorDevToolsClient
- Integrated profiler start/stop into store's startRecording/stopRecording
- Used dynamic imports to avoid circular dependencies

Benefits:
- Cleaner separation of concerns
- Event client is now a thin wrapper around the store
- Follows the same pattern as error-boundary-visualizer
- Less complex code, easier to maintain
- Better adherence to TanStack DevTools architecture