### PR TITLE
feat: Migrate memory-performance-profiler and accessibility-devtools …

### DIFF
--- a/plugins/accessibility-devtools/src/components/ARIAValidator.tsx
+++ b/plugins/accessibility-devtools/src/components/ARIAValidator.tsx
@@ -387,9 +387,9 @@ export function ARIAValidator({ className }: ARIAValidatorProps) {
     
     // Add temporary highlight
     if (element instanceof HTMLElement) {
-      element.style.outline = '3px solid #ef4444';
+      element.style.outline = '3px solid var(--dt-status-error)';
       element.style.outlineOffset = '2px';
-      
+
       setTimeout(() => {
         element.style.outline = '';
         element.style.outlineOffset = '';
@@ -458,7 +458,7 @@ export function ARIAValidator({ className }: ARIAValidatorProps) {
             disabled={isAnalyzing}
             style={mergeStyles(
               COMPONENT_STYLES.button.base,
-              { backgroundColor: COLORS.severity.moderate, borderColor: COLORS.severity.moderate, color: '#ffffff' },
+              { backgroundColor: COLORS.severity.moderate, borderColor: COLORS.severity.moderate, color: "var(--dt-text-on-primary)" },
               isAnalyzing ? COMPONENT_STYLES.button.disabled : {}
             )}
             onMouseEnter={(e) => !isAnalyzing && Object.assign(e.currentTarget.style, COMPONENT_STYLES.button.hover)}
@@ -501,7 +501,7 @@ export function ARIAValidator({ className }: ARIAValidatorProps) {
           <div style={{
             textAlign: 'center',
             padding: SPACING['2xl'],
-            background: 'rgba(231, 76, 60, 0.1)',
+            background: "var(--dt-status-error-bg)",
             borderRadius: RADIUS.lg,
             border: `1px solid ${COLORS.severity.critical}`
           }}>
@@ -520,7 +520,7 @@ export function ARIAValidator({ className }: ARIAValidatorProps) {
           <div style={{
             textAlign: 'center',
             padding: SPACING['2xl'],
-            background: 'rgba(231, 76, 60, 0.1)',
+            background: "var(--dt-status-error-bg)",
             borderRadius: RADIUS.lg,
             border: `1px solid ${COLORS.status.error}`
           }}>
@@ -539,7 +539,7 @@ export function ARIAValidator({ className }: ARIAValidatorProps) {
           <div style={{
             textAlign: 'center',
             padding: SPACING['2xl'],
-            background: 'rgba(243, 156, 18, 0.1)',
+            background: "var(--dt-status-warning-bg)",
             borderRadius: RADIUS.lg,
             border: `1px solid ${COLORS.severity.moderate}`
           }}>
@@ -558,7 +558,7 @@ export function ARIAValidator({ className }: ARIAValidatorProps) {
           <div style={{
             textAlign: 'center',
             padding: SPACING['2xl'],
-            background: 'rgba(52, 152, 219, 0.1)',
+            background: "var(--dt-status-info-bg)",
             borderRadius: RADIUS.lg,
             border: `1px solid ${COLORS.severity.minor}`
           }}>

--- a/plugins/accessibility-devtools/src/components/AccessibilityDevToolsPanel.tsx
+++ b/plugins/accessibility-devtools/src/components/AccessibilityDevToolsPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Trans } from '@lingui/macro';
 import {
   Eye,
@@ -14,7 +14,8 @@ import {
   MapPin,
   BarChart3
 } from 'lucide-react';
-import { PluginPanel, PluginTab, PluginAction, PluginMetric, FilterSection, COLORS, COMPONENT_STYLES, ConfigMenu, type ConfigMenuItem } from '@sucoza/shared-components';
+import { PluginPanel, PluginTab, PluginAction, PluginMetric, FilterSection, COLORS, COMPONENT_STYLES, ConfigMenu, ThemeProvider, type ConfigMenuItem } from '@sucoza/shared-components';
+import '@sucoza/shared-components/dist/styles/theme.css';
 import { useAccessibilityAudit } from '../hooks/useAccessibilityAudit';
 import { IssueList } from './IssueList';
 import { ColorContrastAnalyzer } from './ColorContrastAnalyzer';
@@ -25,12 +26,13 @@ import { FocusDebugger } from './FocusDebugger';
 
 export interface AccessibilityDevToolsPanelProps {
   className?: string;
+  theme?: 'light' | 'dark' | 'auto';
 }
 
 /**
  * Main Accessibility DevTools Panel
  */
-export function AccessibilityDevToolsPanel({ className }: AccessibilityDevToolsPanelProps) {
+function AccessibilityDevToolsPanelInner({ className }: { className?: string }) {
   const {
     currentAudit,
     scanState,
@@ -269,5 +271,21 @@ export function AccessibilityDevToolsPanel({ className }: AccessibilityDevToolsP
   );
 }
 
+export function AccessibilityDevToolsPanel(props: AccessibilityDevToolsPanelProps = {}) {
+  const { theme = 'auto', ...rest } = props;
+
+  const resolvedTheme = useMemo(() => {
+    if (theme === 'auto') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    return theme;
+  }, [theme]);
+
+  return (
+    <ThemeProvider defaultTheme={resolvedTheme}>
+      <AccessibilityDevToolsPanelInner {...rest} />
+    </ThemeProvider>
+  );
+}
 
 export default AccessibilityDevToolsPanel;

--- a/plugins/accessibility-devtools/src/components/ColorContrastAnalyzer.tsx
+++ b/plugins/accessibility-devtools/src/components/ColorContrastAnalyzer.tsx
@@ -381,7 +381,7 @@ function ContrastResultItem({ result, onHighlight }: ContrastResultItemProps) {
     } else if (result.wcagAA) {
       return <CheckCircle style={{ width: '20px', height: '20px', color: COLORS.status.warning }} />;
     } else if (result.largeTextAA) {
-      return <AlertTriangle style={{ width: '20px', height: '20px', color: '#f97316' }} />;
+      return <AlertTriangle style={{ width: '20px', height: '20px', color: "var(--dt-status-warning)" }} />;
     } else {
       return <XCircle style={{ width: '20px', height: '20px', color: COLORS.status.error }} />;
     }
@@ -397,7 +397,7 @@ function ContrastResultItem({ result, onHighlight }: ContrastResultItemProps) {
   const getComplianceStyle = () => {
     if (result.wcagAAA) return COMPONENT_STYLES.tag.success;
     if (result.wcagAA) return COMPONENT_STYLES.tag.warning;
-    if (result.largeTextAA) return { ...COMPONENT_STYLES.tag.base, backgroundColor: 'rgba(249, 115, 22, 0.2)', color: '#f97316' };
+    if (result.largeTextAA) return { ...COMPONENT_STYLES.tag.base, backgroundColor: "var(--dt-status-warning-bg)", color: "var(--dt-status-warning)" };
     return COMPONENT_STYLES.tag.error;
   };
 

--- a/plugins/accessibility-devtools/src/components/FocusDebugger.tsx
+++ b/plugins/accessibility-devtools/src/components/FocusDebugger.tsx
@@ -231,7 +231,7 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
       left: ${rect.left - 3}px;
       width: ${rect.width + 6}px;
       height: ${rect.height + 6}px;
-      border: 3px solid #f59e0b;
+      border: 3px solid var(--dt-status-warning);
       background: rgba(245, 158, 11, 0.1);
       pointer-events: none;
       z-index: 10000;
@@ -256,7 +256,7 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
       }
       
       *:focus {
-        outline: 2px solid #f59e0b !important;
+        outline: 2px solid var(--dt-status-warning) !important;
         outline-offset: 2px !important;
       }
     `;
@@ -307,7 +307,7 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
       case 'poor-contrast':
         return <AlertTriangle style={{ width: '16px', height: '16px', color: COLORS.status.warning }} />;
       case 'focus-trap-broken':
-        return <AlertTriangle style={{ width: '16px', height: '16px', color: '#f97316' }} />;
+        return <AlertTriangle style={{ width: '16px', height: '16px', color: "var(--dt-status-warning)" }} />;
       default:
         return <AlertTriangle style={{ width: '16px', height: '16px', color: COLORS.text.muted }} />;
     }
@@ -344,7 +344,7 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
           marginBottom: SPACING['3xl']
         }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: SPACING.lg }}>
-            <Focus style={{ width: '20px', height: '20px', color: '#f59e0b' }} />
+            <Focus style={{ width: '20px', height: '20px', color: "var(--dt-status-warning)" }} />
             <h2 style={COMPONENT_STYLES.header.title}>
               Focus Debugger
             </h2>
@@ -458,13 +458,13 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
             marginTop: SPACING['4xl'],
             padding: SPACING['2xl'],
             backgroundColor: 'rgba(245, 158, 11, 0.1)',
-            border: '1px solid #f59e0b',
+            border: "1px solid var(--dt-border-primary)",
             borderRadius: RADIUS.lg
           }}>
             <h4 style={{
               fontSize: TYPOGRAPHY.fontSize.base,
               fontWeight: TYPOGRAPHY.fontWeight.medium,
-              color: '#f59e0b',
+              color: "var(--dt-status-warning)",
               marginBottom: SPACING.lg
             }}>
               Currently Focused Element
@@ -472,21 +472,21 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
             <div style={{ display: 'flex', flexDirection: 'column', gap: SPACING.xs }}>
               <p style={{
                 fontSize: TYPOGRAPHY.fontSize.base,
-                color: '#f59e0b'
+                color: "var(--dt-status-warning)"
               }}>
                 <strong>Tag:</strong> {currentFocusedElement.tagName.toLowerCase()}
               </p>
               {currentFocusedElement.id && (
                 <p style={{
                   fontSize: TYPOGRAPHY.fontSize.base,
-                  color: '#f59e0b'
+                  color: "var(--dt-status-warning)"
                 }}>
                   <strong>ID:</strong> {currentFocusedElement.id}
                 </p>
               )}
               <code style={{
                 fontSize: TYPOGRAPHY.fontSize.sm,
-                color: '#f59e0b',
+                color: "var(--dt-status-warning)",
                 backgroundColor: 'rgba(245, 158, 11, 0.2)',
                 padding: `${SPACING.xs} ${SPACING.sm}`,
                 borderRadius: RADIUS.sm,
@@ -709,7 +709,7 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
                         highlightElement(issue.element);
                       }}
                       style={{
-                        color: '#f59e0b',
+                        color: "var(--dt-status-warning)",
                         background: 'transparent',
                         border: 'none',
                         cursor: 'pointer',
@@ -718,7 +718,7 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
                         transition: 'color 0.15s ease'
                       }}
                       onMouseEnter={(e) => e.currentTarget.style.color = COLORS.text.accent}
-                      onMouseLeave={(e) => e.currentTarget.style.color = '#f59e0b'}
+                      onMouseLeave={(e) => e.currentTarget.style.color = "var(--dt-status-warning)"}
                       title="Focus element"
                     >
                       <Eye style={{ width: '16px', height: '16px' }} />
@@ -826,7 +826,7 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
                         highlightElement(entry.element);
                       }}
                       style={{
-                        color: '#f59e0b',
+                        color: "var(--dt-status-warning)",
                         background: 'transparent',
                         border: 'none',
                         cursor: 'pointer',
@@ -835,7 +835,7 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
                         transition: 'color 0.15s ease'
                       }}
                       onMouseEnter={(e) => e.currentTarget.style.color = COLORS.text.accent}
-                      onMouseLeave={(e) => e.currentTarget.style.color = '#f59e0b'}
+                      onMouseLeave={(e) => e.currentTarget.style.color = "var(--dt-status-warning)"}
                       title="Focus element"
                     >
                       <Target style={{ width: '12px', height: '12px' }} />

--- a/plugins/accessibility-devtools/src/components/KeyboardNavVisualizer.tsx
+++ b/plugins/accessibility-devtools/src/components/KeyboardNavVisualizer.tsx
@@ -162,7 +162,7 @@ export function KeyboardNavVisualizer({ className }: KeyboardNavVisualizerProps)
       left: ${rect.left - 2}px;
       width: ${rect.width + 4}px;
       height: ${rect.height + 4}px;
-      border: 2px solid #3b82f6;
+      border: 2px solid var(--dt-border-focus);
       background: rgba(59, 130, 246, 0.1);
       pointer-events: none;
       z-index: 10000;
@@ -175,7 +175,7 @@ export function KeyboardNavVisualizer({ className }: KeyboardNavVisualizerProps)
       position: absolute;
       top: -10px;
       left: -2px;
-      background: #3b82f6;
+      background: var(--dt-border-focus);
       color: white;
       padding: 2px 6px;
       font-size: 12px;

--- a/plugins/accessibility-devtools/src/components/LandmarkMapper.tsx
+++ b/plugins/accessibility-devtools/src/components/LandmarkMapper.tsx
@@ -191,7 +191,7 @@ export function LandmarkMapper({ className }: LandmarkMapperProps) {
     
     // Add temporary highlight
     if (element instanceof HTMLElement) {
-      element.style.outline = '3px solid #8b5cf6';
+      element.style.outline = "3px solid var(--dt-border-focus)";
       element.style.outlineOffset = '2px';
       element.style.backgroundColor = 'rgba(139, 92, 246, 0.1)';
       
@@ -228,7 +228,7 @@ export function LandmarkMapper({ className }: LandmarkMapperProps) {
         left: ${rect.left}px;
         width: ${rect.width}px;
         height: ${rect.height}px;
-        border: 2px solid #8b5cf6;
+        border: 2px solid var(--dt-border-focus);
         background: rgba(139, 92, 246, 0.05);
         pointer-events: none;
         z-index: 9999;
@@ -241,7 +241,7 @@ export function LandmarkMapper({ className }: LandmarkMapperProps) {
         position: absolute;
         top: -2px;
         left: -2px;
-        background: #8b5cf6;
+        background: var(--dt-border-focus);
         color: white;
         padding: 2px 6px;
         font-size: 12px;
@@ -463,13 +463,13 @@ export function LandmarkMapper({ className }: LandmarkMapperProps) {
             <div style={{
               fontSize: TYPOGRAPHY.fontSize.xl,
               fontWeight: TYPOGRAPHY.fontWeight.bold,
-              color: '#9b59b6'
+              color: "var(--dt-border-focus)"
             }}>
               {stats.complementary}
             </div>
             <div style={{
               fontSize: TYPOGRAPHY.fontSize.xs,
-              color: '#9b59b6'
+              color: "var(--dt-border-focus)"
             }}>Aside</div>
           </div>
           <div style={{
@@ -628,13 +628,13 @@ function LandmarkItem({ landmark, isExpanded, onToggleExpanded, onHighlight }: L
     const styles = {
       'main': { color: COLORS.status.info, backgroundColor: 'rgba(52, 152, 219, 0.1)' },
       'navigation': { color: COLORS.status.success, backgroundColor: 'rgba(78, 201, 176, 0.1)' },
-      'complementary': { color: '#8b5cf6', backgroundColor: 'rgba(139, 92, 246, 0.1)' },
+      'complementary': { color: "var(--dt-border-focus)", backgroundColor: 'rgba(139, 92, 246, 0.1)' },
       'banner': { color: COLORS.status.warning, backgroundColor: 'rgba(243, 156, 18, 0.1)' },
-      'contentinfo': { color: '#6366f1', backgroundColor: 'rgba(99, 102, 241, 0.1)' },
+      'contentinfo': { color: "var(--dt-border-focus)", backgroundColor: "var(--dt-status-info-bg)" },
       'region': { color: COLORS.text.secondary, backgroundColor: COLORS.background.tertiary },
-      'article': { color: '#f97316', backgroundColor: 'rgba(249, 115, 22, 0.1)' },
-      'form': { color: '#ec4899', backgroundColor: 'rgba(236, 72, 153, 0.1)' },
-      'search': { color: '#14b8a6', backgroundColor: 'rgba(20, 184, 166, 0.1)' },
+      'article': { color: "var(--dt-status-warning)", backgroundColor: 'rgba(249, 115, 22, 0.1)' },
+      'form': { color: "var(--dt-status-error)", backgroundColor: "var(--dt-status-error-bg)" },
+      'search': { color: "var(--dt-status-success)", backgroundColor: "var(--dt-status-success-bg)" },
     };
     return styles[role as keyof typeof styles] || { color: COLORS.text.secondary, backgroundColor: COLORS.background.tertiary };
   };
@@ -710,7 +710,7 @@ function LandmarkItem({ landmark, isExpanded, onToggleExpanded, onHighlight }: L
         <button
           onClick={onHighlight}
           style={{
-            color: '#6366f1',
+            color: "var(--dt-border-focus)",
             background: 'transparent',
             border: 'none',
             cursor: 'pointer',
@@ -719,7 +719,7 @@ function LandmarkItem({ landmark, isExpanded, onToggleExpanded, onHighlight }: L
             transition: 'color 0.15s ease'
           }}
           onMouseEnter={(e) => e.currentTarget.style.color = COLORS.text.accent}
-          onMouseLeave={(e) => e.currentTarget.style.color = '#6366f1'}
+          onMouseLeave={(e) => e.currentTarget.style.color = "var(--dt-border-focus)"}
           title="Highlight landmark"
         >
           <Eye style={{ width: '16px', height: '16px' }} />

--- a/plugins/memory-performance-profiler/src/components/MemoryProfilerPanel.tsx
+++ b/plugins/memory-performance-profiler/src/components/MemoryProfilerPanel.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { 
+import React, { useState, useEffect, useMemo } from 'react';
+import {
   TrendingUp,
   TrendingDown,
   Minus,
@@ -9,11 +9,11 @@ import {
   Activity,
   Zap
 } from 'lucide-react';
-import { 
-  Tabs, 
-  DataTable, 
-  ProgressBar, 
-  Footer, 
+import {
+  Tabs,
+  DataTable,
+  ProgressBar,
+  Footer,
   Alert,
   Badge,
   StatusIndicator,
@@ -21,12 +21,18 @@ import {
   ScrollableContainer,
   SearchInput,
   ConfigMenu,
+  ThemeProvider,
   type ConfigMenuItem
 } from '@sucoza/shared-components';
+import '@sucoza/shared-components/dist/styles/theme.css';
 import { useMemoryProfilerDevTools } from '../core/devtools-client';
 import type { ComponentMemoryInfo, MemoryLeak, MemoryOptimizationSuggestion } from '../types';
 
-export function MemoryProfilerPanel() {
+interface MemoryProfilerPanelProps {
+  theme?: 'light' | 'dark' | 'auto'
+}
+
+function MemoryProfilerPanelInner() {
   const {
     isRunning,
     currentMemory,
@@ -72,37 +78,37 @@ export function MemoryProfilerPanel() {
           maxWidth: '500px',
           textAlign: 'center',
           padding: '32px',
-          background: '#f8f9fa',
+          background: "var(--dt-bg-secondary)",
           borderRadius: '12px',
           boxShadow: '0 2px 8px rgba(0,0,0,0.1)'
         }}>
           <AlertTriangle size={48} style={{ 
-            color: '#ff9800',
+            color: "var(--dt-status-warning)",
             marginBottom: '16px'
           }} />
           <h3 style={{
             fontSize: '24px',
             fontWeight: 600,
             marginBottom: '12px',
-            color: '#1a1a1a'
+            color: "var(--dt-text-primary)"
           }}>Memory Profiler Not Supported</h3>
           <p style={{
             fontSize: '14px',
-            color: '#666',
+            color: "var(--dt-text-secondary)",
             marginBottom: '24px'
           }}>This browser doesn&apos;t support the required APIs for memory profiling.</p>
           <div style={{
             textAlign: 'left',
-            background: 'white',
+            background: "var(--dt-bg-primary)",
             borderRadius: '8px',
             padding: '20px',
-            border: '1px solid #e0e0e0'
+            border: "1px solid var(--dt-border-primary)"
           }}>
             <h4 style={{
               fontSize: '16px',
               fontWeight: 600,
               marginBottom: '16px',
-              color: '#333'
+              color: "var(--dt-text-primary)"
             }}>Required Features:</h4>
             <ul style={{
               listStyle: 'none',
@@ -116,7 +122,7 @@ export function MemoryProfilerPanel() {
                 gap: '8px',
                 padding: '8px 0',
                 fontSize: '14px',
-                color: supportInfo.memoryAPI ? '#4caf50' : '#f44336'
+                color: supportInfo.memoryAPI ? "var(--dt-status-success)" : "var(--dt-status-error)"
               }}>
                 {supportInfo.memoryAPI ? <CheckCircle size={18} /> : <XCircle size={18} />}
                 Performance Memory API
@@ -127,7 +133,7 @@ export function MemoryProfilerPanel() {
                 gap: '8px',
                 padding: '8px 0',
                 fontSize: '14px',
-                color: supportInfo.performanceObserver ? '#4caf50' : '#f44336'
+                color: supportInfo.performanceObserver ? "var(--dt-status-success)" : "var(--dt-status-error)"
               }}>
                 {supportInfo.performanceObserver ? <CheckCircle size={18} /> : <XCircle size={18} />}
                 Performance Observer API
@@ -138,7 +144,7 @@ export function MemoryProfilerPanel() {
                 gap: '8px',
                 padding: '8px 0',
                 fontSize: '14px',
-                color: supportInfo.reactDevTools ? '#4caf50' : '#666'
+                color: supportInfo.reactDevTools ? "var(--dt-status-success)" : "var(--dt-text-secondary)"
               }}>
                 {supportInfo.reactDevTools ? <CheckCircle size={18} /> : <XCircle size={18} />}
                 React DevTools Hook (optional)
@@ -146,8 +152,8 @@ export function MemoryProfilerPanel() {
             </ul>
             <p style={{
               fontSize: '13px',
-              color: '#666',
-              background: '#f5f5f5',
+              color: "var(--dt-text-secondary)",
+              background: "var(--dt-bg-secondary)",
               padding: '12px',
               borderRadius: '4px',
               margin: 0
@@ -156,7 +162,7 @@ export function MemoryProfilerPanel() {
               <code style={{
                 fontFamily: 'monospace',
                 fontSize: '12px',
-                background: '#e8e8e8',
+                background: "var(--dt-bg-tertiary)",
                 padding: '2px 4px',
                 borderRadius: '3px'
               }}>--enable-precise-memory-info --js-flags=&quot;--expose-gc&quot;</code>
@@ -261,14 +267,14 @@ export function MemoryProfilerPanel() {
       {/* Header with status */}
       <div style={{ 
         padding: '12px 16px', 
-        borderBottom: '1px solid #e5e7eb',
+        borderBottom: "1px solid var(--dt-border-primary)",
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        background: '#f9fafb'
+        background: "var(--dt-bg-secondary)"
       }}>
         <div>
-          <h2 style={{ margin: 0, fontSize: '18px', fontWeight: '600', color: '#1f2937' }}>
+          <h2 style={{ margin: 0, fontSize: '18px', fontWeight: '600', color: "var(--dt-text-primary)" }}>
             Memory & Performance Profiler
           </h2>
         </div>
@@ -520,9 +526,9 @@ function ComponentsTab({ components }: { components: ComponentMemoryInfo[] }) {
 
   const getTrendIcon = (trend: string) => {
     switch (trend) {
-      case 'up': return <TrendingUp size={16} style={{ color: '#f56565' }} />;
-      case 'down': return <TrendingDown size={16} style={{ color: '#38a169' }} />;
-      default: return <Minus size={16} style={{ color: '#718096' }} />;
+      case 'up': return <TrendingUp size={16} style={{ color: "var(--dt-status-error)" }} />;
+      case 'down': return <TrendingDown size={16} style={{ color: "var(--dt-status-success)" }} />;
+      default: return <Minus size={16} style={{ color: "var(--dt-text-tertiary)" }} />;
     }
   };
 
@@ -579,12 +585,12 @@ function ComponentsTab({ components }: { components: ComponentMemoryInfo[] }) {
         <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           {component.suspiciousGrowth ? (
             <>
-              <AlertTriangle size={16} style={{ color: '#f56565' }} />
+              <AlertTriangle size={16} style={{ color: "var(--dt-status-error)" }} />
               <Badge variant="warning" size="xs">Growing</Badge>
             </>
           ) : (
             <>
-              <CheckCircle size={16} style={{ color: '#38a169' }} />
+              <CheckCircle size={16} style={{ color: "var(--dt-status-success)" }} />
               <Badge variant="success" size="xs">Normal</Badge>
             </>
           )}
@@ -636,7 +642,7 @@ function LeaksTab({ leaks }: { leaks: MemoryLeak[] }) {
       <EmptyState
         title="No Memory Leaks Detected"
         description="Great! No memory leaks have been detected in your application."
-        icon={<CheckCircle size={48} style={{ color: '#38a169' }} />}
+        icon={<CheckCircle size={48} style={{ color: "var(--dt-status-success)" }} />}
       />
     );
   }
@@ -645,10 +651,10 @@ function LeaksTab({ leaks }: { leaks: MemoryLeak[] }) {
     <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
       {sortedLeaks.map(leak => (
         <div key={leak.id} style={{ 
-          border: '1px solid #e2e8f0', 
+          border: "1px solid var(--dt-border-primary)", 
           borderRadius: '8px', 
           padding: '16px',
-          background: 'white'
+          background: "var(--dt-bg-primary)"
         }}>
           <div style={{ 
             display: 'flex', 
@@ -657,12 +663,12 @@ function LeaksTab({ leaks }: { leaks: MemoryLeak[] }) {
             marginBottom: '12px'
           }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-              <AlertTriangle size={20} style={{ color: '#f56565' }} />
+              <AlertTriangle size={20} style={{ color: "var(--dt-status-error)" }} />
               <div>
                 <div style={{ fontWeight: '600', fontSize: '14px' }}>
                   {leak.component || 'Unknown Component'}
                 </div>
-                <div style={{ fontSize: '12px', color: '#718096' }}>
+                <div style={{ fontSize: '12px', color: "var(--dt-text-tertiary)" }}>
                   {leak.type}
                 </div>
               </div>
@@ -672,7 +678,7 @@ function LeaksTab({ leaks }: { leaks: MemoryLeak[] }) {
             </Badge>
           </div>
           
-          <div style={{ marginBottom: '12px', fontSize: '14px', color: '#2d3748' }}>
+          <div style={{ marginBottom: '12px', fontSize: '14px', color: "var(--dt-text-primary)" }}>
             {leak.description}
           </div>
 
@@ -681,7 +687,7 @@ function LeaksTab({ leaks }: { leaks: MemoryLeak[] }) {
             gap: '16px', 
             marginBottom: '12px',
             fontSize: '12px',
-            color: '#718096'
+            color: "var(--dt-text-tertiary)"
           }}>
             <span>Impact: ~{(leak.estimatedMemoryImpact / 1024).toFixed(1)} KB</span>
             <span>Detected: {new Date(leak.detectedAt).toLocaleTimeString()}</span>
@@ -689,7 +695,7 @@ function LeaksTab({ leaks }: { leaks: MemoryLeak[] }) {
 
           <div style={{ 
             padding: '12px',
-            background: '#f7fafc',
+            background: "var(--dt-bg-secondary)",
             borderRadius: '6px',
             marginBottom: '12px',
             fontSize: '13px'
@@ -703,7 +709,7 @@ function LeaksTab({ leaks }: { leaks: MemoryLeak[] }) {
               alignItems: 'center',
               gap: '6px',
               padding: '8px 12px',
-              background: '#4299e1',
+              background: "var(--dt-border-focus)",
               color: 'white',
               border: 'none',
               borderRadius: '6px',
@@ -844,4 +850,21 @@ function TimelineTab({ timeline }: any) {
       )}
     </div>
   );
+}
+
+export function MemoryProfilerPanel(props: MemoryProfilerPanelProps = {}) {
+  const { theme = "auto" } = props
+
+  const resolvedTheme = useMemo(() => {
+    if (theme === "auto") {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+    }
+    return theme
+  }, [theme])
+
+  return (
+    <ThemeProvider defaultTheme={resolvedTheme}>
+      <MemoryProfilerPanelInner />
+    </ThemeProvider>
+  )
 }


### PR DESCRIPTION
…to unified theming

- Migrate memory-performance-profiler plugin (25 colors converted)
  - Add ThemeProvider wrapper with theme prop support
  - Convert all hardcoded hex colors to CSS variables
  - Replace inline theme ternaries with CSS custom properties

- Migrate accessibility-devtools plugin (24 colors converted)
  - Add ThemeProvider wrapper to main panel
  - Convert hardcoded colors in ARIAValidator component
  - Convert rgba backgrounds to CSS variable equivalents in ColorContrastAnalyzer
  - Update FocusDebugger, KeyboardNavVisualizer, and LandmarkMapper components
  - Replace all event handler color assignments with CSS variables

Both plugins now support light/dark/auto theme modes and use consistent CSS custom properties (--dt-*) from @sucoza/shared-components.