### PR TITLE
fix: deduplicate CSS keyframes, add event listener cleanup, remove dead code

### DIFF
--- a/packages/shared-components/src/components/Footer.tsx
+++ b/packages/shared-components/src/components/Footer.tsx
@@ -449,17 +449,8 @@ export function Footer({
       
       {/* Animation for pulse */}
       <style>{`
-        @keyframes pulse {
-          0%, 100% {
-            opacity: 1;
-          }
-          50% {
-            opacity: 0.5;
-          }
-        }
-
         .animate-pulse {
-          animation: pulse 2s ease-in-out infinite;
+          animation: dt-pulse 2s ease-in-out infinite;
         }
       `}</style>
     </div>

--- a/packages/shared-components/src/components/StatusIndicator.tsx
+++ b/packages/shared-components/src/components/StatusIndicator.tsx
@@ -135,14 +135,7 @@ export function StatusIndicator({
     }
   ` : '';
   
-  // Loading animation
-  const loadingAnimation = status === 'loading' && animate ? `
-    @keyframes spin {
-      to {
-        transform: rotate(360deg);
-      }
-    }
-  ` : '';
+
   
   // Base container styles
   const containerStyles: React.CSSProperties = {
@@ -170,7 +163,7 @@ export function StatusIndicator({
           border: `2px solid ${COLORS.border.primary}`,
           borderTopColor: colors.bg,
           backgroundColor: 'transparent',
-          animation: 'spin 1s linear infinite',
+          animation: 'dt-spin 1s linear infinite',
         }),
       }}
     />
@@ -194,7 +187,7 @@ export function StatusIndicator({
         color: colors.bg,
         flexShrink: 0,
         ...(status === 'loading' && animate && {
-          animation: 'spin 1s linear infinite',
+          animation: 'dt-spin 1s linear infinite',
         }),
       }}
     >
@@ -263,7 +256,7 @@ export function StatusIndicator({
             alignItems: 'center',
             justifyContent: 'center',
             ...(status === 'loading' && animate && {
-              animation: 'spin 1s linear infinite',
+              animation: 'dt-spin 1s linear infinite',
             }),
           }}
         >
@@ -281,7 +274,7 @@ export function StatusIndicator({
           justifyContent: 'center',
           fontSize: dimensions.badge,
           ...(status === 'loading' && animate && {
-            animation: 'spin 1s linear infinite',
+            animation: 'dt-spin 1s linear infinite',
           }),
         }}
       >
@@ -308,7 +301,6 @@ export function StatusIndicator({
   return (
     <div className={className} style={containerStyles} onClick={onClick}>
       {pulseAnimation && <style>{pulseAnimation}</style>}
-      {loadingAnimation && <style>{loadingAnimation}</style>}
       {status === 'loading' && animate && variant === 'pill' && (
         <style>{`
           @keyframes slide {

--- a/packages/shared-components/src/components/Toast.tsx
+++ b/packages/shared-components/src/components/Toast.tsx
@@ -395,16 +395,7 @@ function ToastItem({
         }
 
         .animate-spin {
-          animation: spin 1s linear infinite;
-        }
-
-        @keyframes spin {
-          from {
-            transform: rotate(0deg);
-          }
-          to {
-            transform: rotate(360deg);
-          }
+          animation: dt-spin 1s linear infinite;
         }
       `}</style>
     </div>

--- a/packages/shared-components/src/components/Toolbar.tsx
+++ b/packages/shared-components/src/components/Toolbar.tsx
@@ -438,17 +438,8 @@ export function Toolbar({
       
       {/* Animation for refresh */}
       <style>{`
-        @keyframes spin {
-          from {
-            transform: rotate(0deg);
-          }
-          to {
-            transform: rotate(360deg);
-          }
-        }
-
         .animate-spin {
-          animation: spin 1s linear infinite;
+          animation: dt-spin 1s linear infinite;
         }
       `}</style>
     </div>

--- a/packages/shared-components/src/components/VirtualList.tsx
+++ b/packages/shared-components/src/components/VirtualList.tsx
@@ -315,9 +315,9 @@ export function VirtualList<T>({
               border: `2px solid ${COLORS.border.primary}`,
               borderTopColor: COLORS.text.accent,
               borderRadius: '50%',
-              animation: 'spin 1s linear infinite',
+              animation: 'dt-spin 1s linear infinite',
             }} />
-            <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+
           </div>
         )}
       </ScrollableContainer>

--- a/plugins/browser-automation-test-recorder/src/components/tabs/CollaborationTab.tsx
+++ b/plugins/browser-automation-test-recorder/src/components/tabs/CollaborationTab.tsx
@@ -256,7 +256,6 @@ export const CollaborationTab: React.FC<CollaborationTabProps> = ({
               className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
               onClick={() => {
                 // Handle sign in
-                // console.log('Sign in clicked');
               }}
             >
               Sign In

--- a/plugins/browser-automation-test-recorder/src/components/tabs/RecorderTab.tsx
+++ b/plugins/browser-automation-test-recorder/src/components/tabs/RecorderTab.tsx
@@ -53,7 +53,7 @@ export default function RecorderTab({ state, dispatch, compact: _compact }: TabC
       await eventClient.startRecording();
       setRealTimeEventCount(0);
     } catch {
-      // console.error('Failed to start recording');
+      // silently ignore
     } finally {
       setIsLoading(false);
     }
@@ -64,7 +64,7 @@ export default function RecorderTab({ state, dispatch, compact: _compact }: TabC
     try {
       await eventClient.stopRecording();
     } catch {
-      // console.error('Failed to stop recording');
+      // silently ignore
     } finally {
       setIsLoading(false);
     }
@@ -88,11 +88,10 @@ export default function RecorderTab({ state, dispatch, compact: _compact }: TabC
     try {
       const screenshot = await eventClient.takeScreenshot({ fullPage: false });
       if (screenshot) {
-        // console.log('Screenshot captured:', screenshot);
         // Could emit event or show notification
       }
     } catch {
-      // console.error('Screenshot failed');
+      // silently ignore
     }
   };
 

--- a/plugins/browser-automation-test-recorder/src/components/tabs/SettingsTab.tsx
+++ b/plugins/browser-automation-test-recorder/src/components/tabs/SettingsTab.tsx
@@ -212,7 +212,6 @@ export default function SettingsTab({ state, dispatch, compact: _compact }: TabC
           <button
             onClick={() => {
               // This would trigger a file picker
-              // console.log('Import settings');
             }}
             className="flex items-center gap-2 px-3 py-2 border border-gray-300 rounded text-sm hover:bg-gray-50 transition-colors"
           >

--- a/plugins/browser-automation-test-recorder/src/core/accessibility/accessibility-auditor.ts
+++ b/plugins/browser-automation-test-recorder/src/core/accessibility/accessibility-auditor.ts
@@ -262,7 +262,7 @@ export class AccessibilityAuditor {
         getRules: this.mockAxeGetRules.bind(this),
       } as AxeCoreApi;
     } catch {
-      // // console.warn('Failed to initialize axe-core');
+      // silently ignore
     }
   }
 

--- a/plugins/browser-automation-test-recorder/src/core/cdp-client.ts
+++ b/plugins/browser-automation-test-recorder/src/core/cdp-client.ts
@@ -94,13 +94,11 @@ export class CDPClient {
       this.websocket.onopen = () => {
         clearTimeout(timeout);
         this.isConnected = true;
-        // // console.log('CDPClient: Connected to DevTools Protocol');
         resolve();
       };
 
       this.websocket.onerror = (_error) => {
         clearTimeout(timeout);
-        // // // console.error('CDPClient: WebSocket error:', error);
         reject(new Error('Failed to connect to CDP'));
       };
 
@@ -111,7 +109,6 @@ export class CDPClient {
       this.websocket.onclose = () => {
         this.isConnected = false;
         this.cleanup();
-        // // // console.log('CDPClient: Connection closed');
       };
     });
   }
@@ -244,7 +241,7 @@ export class CDPClient {
 
       return null;
     } catch {
-      // // console.error('CDPClient: Error finding element');
+      // silently ignore
       return null;
     }
   }
@@ -264,7 +261,7 @@ export class CDPClient {
 
       return result.node;
     } catch {
-      // // console.error('CDPClient: Error getting node info');
+      // silently ignore
       return null;
     }
   }
@@ -279,7 +276,6 @@ export class CDPClient {
       // Find element
       const element = await this.findElement(selector);
       if (!element || !element.objectId) {
-        // // console.warn('CDPClient: Element not found for highlighting:', selector);
         return;
       }
 
@@ -310,7 +306,7 @@ export class CDPClient {
       }, 3000);
 
     } catch {
-      // // console.error('CDPClient: Error highlighting element');
+      // silently ignore
     }
   }
 
@@ -486,7 +482,7 @@ export class CDPClient {
           try {
             callback(message.params);
           } catch {
-            // // console.error('CDPClient: Error in event listener:', error);
+            // silently ignore
           }
         });
       }
@@ -499,17 +495,17 @@ export class CDPClient {
   private setupEventListeners(): void {
     // Handle console messages
     this.addEventListener('Runtime.consoleAPICalled', (_params: any) => {
-      // // console.log('CDP Console:', params);
+      // Handle console messages
     });
 
     // Handle JavaScript exceptions
     this.addEventListener('Runtime.exceptionThrown', (_params: any) => {
-      // // console.error('CDP Exception:', params.exceptionDetails);
+      // Handle JavaScript exceptions
     });
 
     // Handle network events
     this.addEventListener('Network.requestWillBeSent', (_params: any) => {
-      // // console.log('CDP Network Request:', params.request.url);
+      // Handle network events
     });
   }
 

--- a/plugins/browser-automation-test-recorder/src/core/code-generator.ts
+++ b/plugins/browser-automation-test-recorder/src/core/code-generator.ts
@@ -154,7 +154,7 @@ export class CodeGenerator {
           
           variants.push(test);
         } catch {
-          // // console.warn(`Failed to generate ${format}/${language} variant:`, _error);
+          // silently ignore
         }
       }
     }

--- a/plugins/browser-automation-test-recorder/src/core/collaboration/collaboration-manager.ts
+++ b/plugins/browser-automation-test-recorder/src/core/collaboration/collaboration-manager.ts
@@ -124,8 +124,6 @@ export class CollaborationManager {
 
     this.initialized = true;
     this.connected = true;
-
-    // // console.log('Collaboration system initialized successfully');
   }
 
   /**
@@ -149,8 +147,6 @@ export class CollaborationManager {
     this.connected = false;
     this.currentUser = null;
     this.currentTeam = null;
-
-    // // console.log('Collaboration system shutdown');
   }
 
   /**
@@ -566,7 +562,7 @@ export class CollaborationManager {
       try {
         await this.performSync();
       } catch {
-        // // console.error('Sync error:', err);
+        // silently ignore
       }
     }, this.config.sync.interval);
 
@@ -576,17 +572,14 @@ export class CollaborationManager {
 
   private async performSync(): Promise<void> {
     // Implementation would sync with remote server
-    // // console.log('Performing collaboration sync...');
   }
 
   private async connectNotifications(): Promise<void> {
     // Implementation would connect to real-time notification service
-    // // console.log('Connecting to notifications...');
   }
 
   private async disconnectNotifications(): Promise<void> {
     // Implementation would disconnect from notification service
-    // // console.log('Disconnecting from notifications...');
   }
 
   private emitNotification(notification: CollaborationNotification): void {
@@ -596,7 +589,7 @@ export class CollaborationManager {
         try {
           handler(notification);
         } catch {
-          // // console.error('Error in notification handler:', err);
+          // silently ignore
         }
       });
     }

--- a/plugins/browser-automation-test-recorder/src/core/collaboration/comments/visual-annotations.ts
+++ b/plugins/browser-automation-test-recorder/src/core/collaboration/comments/visual-annotations.ts
@@ -611,7 +611,7 @@ class AnnotationEventBus {
         try {
           callback(data);
         } catch {
-          // // console.error('Error in annotation event listener:', error);
+          // silently ignore
         }
       });
     }

--- a/plugins/browser-automation-test-recorder/src/core/recorder.ts
+++ b/plugins/browser-automation-test-recorder/src/core/recorder.ts
@@ -130,8 +130,6 @@ export class EventRecorder {
     
     // Record initial page state
     await this.recordPageState();
-    
-    // // console.log(`EventRecorder: Started recording session ${this.sessionId}`);
   }
 
   /**
@@ -154,8 +152,7 @@ export class EventRecorder {
     // Return recorded events
     const events = [...this.eventBuffer];
     this.eventBuffer = [];
-    
-    // // console.log(`EventRecorder: Stopped recording, captured ${events.length} events`);
+
     return events;
   }
 
@@ -165,7 +162,6 @@ export class EventRecorder {
   pauseRecording(): void {
     if (!this._isRecording) return;
     this._isPaused = true;
-    // // console.log('EventRecorder: Recording paused');
   }
 
   /**
@@ -174,7 +170,6 @@ export class EventRecorder {
   resumeRecording(): void {
     if (!this._isRecording) return;
     this._isPaused = false;
-    // // console.log('EventRecorder: Recording resumed');
   }
 
   /**
@@ -406,7 +401,7 @@ export class EventRecorder {
       this.lastEventTime = Date.now();
       
     } catch {
-      // console.error('EventRecorder: Error processing event');
+      // silently ignore
     }
   }
 
@@ -882,7 +877,7 @@ export class EventRecorder {
         data: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==', // Minimal PNG
       };
     } catch {
-      // console.error('EventRecorder: Failed to capture screenshot');
+      // silently ignore
       return undefined;
     }
   }

--- a/plugins/browser-automation-test-recorder/src/core/visual-regression/baseline-manager.ts
+++ b/plugins/browser-automation-test-recorder/src/core/visual-regression/baseline-manager.ts
@@ -200,7 +200,7 @@ export class BaselineManager {
       this.cache.delete(id);
       return true;
     } catch {
-      // // console.error('Failed to delete baseline');
+      // silently ignore
       return false;
     }
   }
@@ -362,18 +362,15 @@ export class BaselineManager {
    */
   private async storeInCloud(_baseline: BaselineImage): Promise<void> {
     // Implement cloud storage logic based on provider
-    // // console.log('Storing baseline in cloud:', baseline.id);
   }
 
   private async loadFromCloud(_id: string, _environment?: string): Promise<BaselineImage | null> {
     // Implement cloud loading logic
-    // // console.log('Loading baseline from cloud:', id);
     return null;
   }
 
   private async removeFromCloud(_id: string): Promise<void> {
     // Implement cloud removal logic
-    // // console.log('Removing baseline from cloud:', id);
   }
 
   /**
@@ -381,18 +378,15 @@ export class BaselineManager {
    */
   private async storeInGit(_baseline: BaselineImage): Promise<void> {
     // Implement git storage logic
-    // // console.log('Storing baseline in git:', baseline.id);
   }
 
   private async loadFromGit(_id: string, _environment?: string): Promise<BaselineImage | null> {
     // Implement git loading logic
-    // // console.log('Loading baseline from git:', id);
     return null;
   }
 
   private async removeFromGit(_id: string): Promise<void> {
     // Implement git removal logic
-    // // console.log('Removing baseline from git:', id);
   }
 
   /**

--- a/plugins/design-system-inspector/src/utils/component-detector.ts
+++ b/plugins/design-system-inspector/src/utils/component-detector.ts
@@ -262,7 +262,7 @@ export function setupComponentObserver(): { disconnect: () => void } {
 
   // Start observing when DOM is ready
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', startObserving);
+    document.addEventListener('DOMContentLoaded', startObserving, { once: true });
   } else {
     startObserving();
   }
@@ -273,6 +273,7 @@ export function setupComponentObserver(): { disconnect: () => void } {
         observer.disconnect();
         isObserving = false;
       }
+      document.removeEventListener('DOMContentLoaded', startObserving);
     },
   };
 }

--- a/plugins/error-boundary-visualizer/src/__tests__/unit/ErrorBoundaryDevToolsPanel.test.tsx
+++ b/plugins/error-boundary-visualizer/src/__tests__/unit/ErrorBoundaryDevToolsPanel.test.tsx
@@ -421,15 +421,15 @@ describe('ErrorBoundaryDevToolsPanel', () => {
       expect(wrapper).toBeInTheDocument();
     });
 
-    it('should include CSS animation keyframes for pulse', () => {
+    it('should not include unused inline CSS animations', () => {
       render(<ErrorBoundaryDevToolsPanel />);
 
-      // Check that at least one style tag with the pulse animation is rendered
+      // Pulse animation was removed as dead code - dt-pulse is available via theme.css
       const styleTags = document.querySelectorAll('style');
-      const hasPulseAnimation = Array.from(styleTags).some(
+      const hasInlinePulse = Array.from(styleTags).some(
         tag => tag.textContent?.includes('@keyframes pulse')
       );
-      expect(hasPulseAnimation).toBe(true);
+      expect(hasInlinePulse).toBe(false);
     });
 
     it('should position the config menu absolutely in top-right corner', () => {

--- a/plugins/error-boundary-visualizer/src/components/ErrorBoundaryDevToolsPanel.tsx
+++ b/plugins/error-boundary-visualizer/src/components/ErrorBoundaryDevToolsPanel.tsx
@@ -120,12 +120,7 @@ function ErrorBoundaryDevToolsPanelInner() {
 
   return (
     <>
-      <style>{`
-        @keyframes pulse {
-          0%, 100% { opacity: 1; }
-          50% { opacity: 0.5; }
-        }
-      `}</style>
+
       <div style={{ position: 'relative', height: '100%' }}>
         <PluginPanel
           title={<Trans>Error Boundary DevTools</Trans>}

--- a/plugins/form-state-inspector/src/__tests__/unit/index.test.ts
+++ b/plugins/form-state-inspector/src/__tests__/unit/index.test.ts
@@ -151,7 +151,8 @@ describe('Form State Inspector Index', () => {
       
       expect(mockDocument.addEventListener).toHaveBeenCalledWith(
         'DOMContentLoaded',
-        expect.any(Function)
+        expect.any(Function),
+        { once: true }
       );
       
       // Simulate DOMContentLoaded event

--- a/plugins/form-state-inspector/src/index.ts
+++ b/plugins/form-state-inspector/src/index.ts
@@ -72,7 +72,7 @@ export function initializeFormStateInspector() {
           const formId = formElement.id || formElement.name || `form-${index}`;
           trackHTMLForm(formElement, formId);
         });
-      });
+      }, { once: true });
     }
 
     // console.log('🔍 Form State Inspector initialized');

--- a/plugins/stress-testing-devtools/src/styles.css
+++ b/plugins/stress-testing-devtools/src/styles.css
@@ -78,12 +78,7 @@
 .running-indicator {
   color: var(--dt-status-success);
   font-weight: 500;
-  animation: pulse 2s infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  animation: dt-pulse 2s infinite;
 }
 
 /* Test Runner */


### PR DESCRIPTION
## Summary
- **Deduplicate CSS @keyframes**: Consolidated 7 duplicate `@keyframes spin` and 3 duplicate `@keyframes pulse` definitions by referencing shared `dt-spin`/`dt-pulse` animations from theme.css
- **Fix event listener leaks**: Added `destroy()` method to `ReactRouterAdapter` for proper cleanup of `popstate`/`hashchange` listeners and `history.pushState`/`replaceState` monkey-patches; added `{ once: true }` to `DOMContentLoaded` listeners in form-state-inspector and design-system-inspector; added `removeEventListener` to design-system-inspector's disconnect cleanup
- **Remove dead debug code**: Cleaned up ~40 commented-out console statements from browser-automation-test-recorder, removed unused `_paramPattern` variable, removed dead `@keyframes pulse` CSS from error-boundary-visualizer
- **Update tests**: Fixed form-state-inspector test to expect `{ once: true }` option, updated error-boundary-visualizer test to reflect removal of dead CSS

## Test plan
- [x] All 27 projects build successfully
- [x] form-state-inspector tests pass (79/79)
- [x] error-boundary-visualizer tests pass (158/158)
- [x] No new lint errors introduced (pre-existing eslint config issue in router-devtools unrelated to changes)