### PR TITLE
fix: improve type safety, fix memory leaks, and correct React key props

### DIFF
--- a/packages/devtools-importer/src/port.ts
+++ b/packages/devtools-importer/src/port.ts
@@ -1,3 +1,4 @@
+import type { AddressInfo } from "node:net";
 import net from "node:net";
 
 /**
@@ -11,7 +12,7 @@ export async function findAvailablePort(min: number, max: number): Promise<numbe
       server.unref();
       server.on("error", reject);
       server.listen(port, () => {
-        const { port: chosen } = server.address() as any;
+        const { port: chosen } = server.address() as AddressInfo;
         server.close(() => resolve(chosen));
       });
     });

--- a/packages/feature-flags/src/evaluator.ts
+++ b/packages/feature-flags/src/evaluator.ts
@@ -154,7 +154,7 @@ export class FlagEvaluator {
       if (!userSegment || !flag.targeting.userSegments.includes(userSegment)) {
         // Check if user matches any segment rules
         const matchedSegment = userSegments.find(segment => 
-          flag.targeting!.userSegments!.includes(segment.id) &&
+          flag.targeting.userSegments.includes(segment.id) &&
           this.matchesSegmentRules(segment, context)
         );
         

--- a/packages/feature-flags/src/manager.ts
+++ b/packages/feature-flags/src/manager.ts
@@ -229,7 +229,7 @@ export class FeatureFlagManager {
     if (!this.listeners.has(event)) {
       this.listeners.set(event, new Set());
     }
-    this.listeners.get(event)!.add(listener);
+    this.listeners.get(event)?.add(listener);
   }
 
   off(event: string, listener: (data: any) => void): void {

--- a/packages/i18n/src/core/i18n.ts
+++ b/packages/i18n/src/core/i18n.ts
@@ -394,7 +394,7 @@ export class I18n implements I18nInstance {
     if (!this._listeners.has(event)) {
       this._listeners.set(event, new Set());
     }
-    this._listeners.get(event)!.add(listener);
+    this._listeners.get(event)?.add(listener);
 
     // Return unsubscribe function
     return () => {

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -130,12 +130,13 @@ export class Logger {
       trace: console.trace.bind(console),
     };
 
-    console.log = (...args) => this.interceptConsoleCall('info', args, this.originalConsole!.log);
-    console.debug = (...args) => this.interceptConsoleCall('debug', args, this.originalConsole!.debug);
-    console.info = (...args) => this.interceptConsoleCall('info', args, this.originalConsole!.info);
-    console.warn = (...args) => this.interceptConsoleCall('warn', args, this.originalConsole!.warn);
-    console.error = (...args) => this.interceptConsoleCall('error', args, this.originalConsole!.error);
-    console.trace = (...args) => this.interceptConsoleCall('trace', args, this.originalConsole!.trace);
+    const orig = this.originalConsole;
+    console.log = (...args) => this.interceptConsoleCall('info', args, orig.log);
+    console.debug = (...args) => this.interceptConsoleCall('debug', args, orig.debug);
+    console.info = (...args) => this.interceptConsoleCall('info', args, orig.info);
+    console.warn = (...args) => this.interceptConsoleCall('warn', args, orig.warn);
+    console.error = (...args) => this.interceptConsoleCall('error', args, orig.error);
+    console.trace = (...args) => this.interceptConsoleCall('trace', args, orig.trace);
 
     this.consoleIntercepted = true;
   }
@@ -652,7 +653,7 @@ export class Logger {
     if (!this.listeners.has(event)) {
       this.listeners.set(event, new Set());
     }
-    this.listeners.get(event)!.add(listener);
+    this.listeners.get(event)?.add(listener);
   }
 
   off(event: string, listener: (data: any) => void): void {

--- a/packages/shared-components/src/components/Accordion.tsx
+++ b/packages/shared-components/src/components/Accordion.tsx
@@ -345,19 +345,21 @@ function AccordionContent({
   
   useEffect(() => {
     if (!animate || !contentRef.current || !innerRef.current) return;
-    
+
+    let timerId: ReturnType<typeof setTimeout>;
+
     if (isExpanded) {
       // Expanding
       setIsAnimating(true);
       setHeight(0);
-      
+
       requestAnimationFrame(() => {
         if (innerRef.current) {
           setHeight(innerRef.current.scrollHeight);
         }
       });
-      
-      setTimeout(() => {
+
+      timerId = setTimeout(() => {
         setHeight('auto');
         setIsAnimating(false);
       }, 200);
@@ -366,16 +368,18 @@ function AccordionContent({
       if (innerRef.current) {
         setIsAnimating(true);
         setHeight(innerRef.current.scrollHeight);
-        
+
         requestAnimationFrame(() => {
           setHeight(0);
         });
-        
-        setTimeout(() => {
+
+        timerId = setTimeout(() => {
           setIsAnimating(false);
         }, 200);
       }
     }
+
+    return () => clearTimeout(timerId);
   }, [isExpanded, animate]);
   
   if (!animate) {

--- a/plugins/accessibility-devtools/src/components/ARIAValidator.tsx
+++ b/plugins/accessibility-devtools/src/components/ARIAValidator.tsx
@@ -689,9 +689,9 @@ export function ARIAValidator({ className }: ARIAValidatorProps) {
           </div>
         ) : (
           <div>
-            {filteredIssues.map((issue, index) => (
+            {filteredIssues.map((issue) => (
               <div
-                key={index}
+                key={`${issue.rule}-${issue.selector}`}
                 style={{
                   padding: SPACING['4xl'],
                   borderBottom: `1px solid ${COLORS.border.primary}`,

--- a/plugins/accessibility-devtools/src/components/FocusDebugger.tsx
+++ b/plugins/accessibility-devtools/src/components/FocusDebugger.tsx
@@ -658,9 +658,9 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
             </div>
           ) : (
             <div>
-              {focusIssues.map((issue, index) => (
+              {focusIssues.map((issue) => (
                 <div
-                  key={index}
+                  key={`${issue.issue}-${issue.selector}`}
                   style={{
                     padding: SPACING['4xl'],
                     borderLeft: `4px solid ${getIssueColor(issue.severity)}`,
@@ -783,9 +783,9 @@ export function FocusDebugger({ className }: FocusDebuggerProps) {
             </div>
           ) : (
             <div>
-              {focusHistory.slice().reverse().map((entry, index) => (
+              {focusHistory.slice().reverse().map((entry) => (
                 <div
-                  key={index}
+                  key={entry.timestamp}
                   style={{
                     padding: SPACING['2xl'],
                     cursor: 'pointer',


### PR DESCRIPTION
## Summary
- **Memory leak fixes**: Add `setTimeout` cleanup return in Accordion `useEffect`; fix stale closure bug in BundleAnalyzer timeout by using a ref instead of reading state directly
- **Type safety improvements**: Replace `Map.get()!` non-null assertions with optional chaining (`?.`) in logger, feature-flags, and i18n event systems; replace `as any` with `AddressInfo` type in devtools-importer; remove unnecessary `!` assertions in feature-flags evaluator
- **React reconciliation fixes**: Replace `index`-as-key with stable composite keys in FocusDebugger (`issue+selector`, `timestamp`) and ARIAValidator (`rule+selector`) — prevents DOM/state mismatches when lists are filtered or reversed

## Test plan
- [x] All 27 projects build successfully
- [x] All 27 project test suites pass