### PR TITLE
fix: add package exports/sideEffects, fix rollup declarations

### DIFF
--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/plugins/accessibility-devtools/package.json
+++ b/plugins/accessibility-devtools/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/api-mock-interceptor/package.json
+++ b/plugins/api-mock-interceptor/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/auth-permissions-mock/package.json
+++ b/plugins/auth-permissions-mock/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/browser-automation-test-recorder/package.json
+++ b/plugins/browser-automation-test-recorder/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/bundle-impact-analyzer/package.json
+++ b/plugins/bundle-impact-analyzer/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/design-system-inspector/package.json
+++ b/plugins/design-system-inspector/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/error-boundary-visualizer/package.json
+++ b/plugins/error-boundary-visualizer/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/feature-flag-manager/package.json
+++ b/plugins/feature-flag-manager/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/form-state-inspector/package.json
+++ b/plugins/form-state-inspector/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/graphql-devtools/package.json
+++ b/plugins/graphql-devtools/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/graphql-devtools/rollup.config.mjs
+++ b/plugins/graphql-devtools/rollup.config.mjs
@@ -30,6 +30,8 @@ export default [
       commonjs(),
       typescript({
         tsconfig: './tsconfig.json',
+        declaration: true,
+        declarationDir: 'dist',
         exclude: ['**/*.test.*', '**/*.spec.*'],
       }),
       postcss({

--- a/plugins/i18n-devtools/package.json
+++ b/plugins/i18n-devtools/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/logger-devtools/package.json
+++ b/plugins/logger-devtools/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/memory-performance-profiler/package.json
+++ b/plugins/memory-performance-profiler/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/memory-performance-profiler/rollup.config.mjs
+++ b/plugins/memory-performance-profiler/rollup.config.mjs
@@ -30,6 +30,8 @@ export default [
       commonjs(),
       typescript({
         tsconfig: './tsconfig.json',
+        declaration: true,
+        declarationDir: 'dist',
         exclude: ['**/*.test.*', '**/*.spec.*', '**/example/**'],
       }),
       postcss({

--- a/plugins/render-waste-detector/package.json
+++ b/plugins/render-waste-detector/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/render-waste-detector/rollup.config.mjs
+++ b/plugins/render-waste-detector/rollup.config.mjs
@@ -30,6 +30,8 @@ export default [
       commonjs(),
       typescript({
         tsconfig: './tsconfig.json',
+        declaration: true,
+        declarationDir: 'dist',
         exclude: ['**/*.test.*', '**/*.spec.*'],
       }),
       postcss({

--- a/plugins/router-devtools/package.json
+++ b/plugins/router-devtools/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/security-audit-panel/package.json
+++ b/plugins/security-audit-panel/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/security-audit-panel/rollup.config.mjs
+++ b/plugins/security-audit-panel/rollup.config.mjs
@@ -30,6 +30,8 @@ export default [
       commonjs(),
       typescript({
         tsconfig: './tsconfig.json',
+        declaration: true,
+        declarationDir: 'dist',
         exclude: ['**/*.test.*', '**/*.spec.*'],
       }),
       postcss({

--- a/plugins/stress-testing-devtools/package.json
+++ b/plugins/stress-testing-devtools/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/visual-regression-monitor/package.json
+++ b/plugins/visual-regression-monitor/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/visual-regression-monitor/rollup.config.mjs
+++ b/plugins/visual-regression-monitor/rollup.config.mjs
@@ -30,6 +30,8 @@ export default [
       commonjs(),
       typescript({
         tsconfig: './tsconfig.json',
+        declaration: true,
+        declarationDir: 'dist',
         exclude: ['**/*.test.*', '**/*.spec.*'],
       }),
       postcss({

--- a/plugins/visual-regression-monitor/src/core/screenshot-engine.ts
+++ b/plugins/visual-regression-monitor/src/core/screenshot-engine.ts
@@ -905,7 +905,7 @@ export class ScreenshotEngine {
             });
           });
           
-          Promise.all(promises).then(resolve);
+          Promise.all(promises).then(resolve).catch(resolve);
           setTimeout(resolve, 10000); // Overall timeout
         })
       `);

--- a/plugins/websocket-signalr-devtools/package.json
+++ b/plugins/websocket-signalr-devtools/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/plugins/zustand-devtools/package.json
+++ b/plugins/zustand-devtools/package.json
@@ -5,6 +5,15 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary
- **Package exports**: Added `exports` field with ESM/CJS/types conditions to all 20 plugin package.json files for proper dual package support
- **Tree-shaking**: Added `sideEffects: false` to all 20 plugins and 2 shared packages (plugin-core, shared-components) to enable bundler tree-shaking
- **TypeScript declarations**: Added `declaration: true` and `declarationDir` to 5 rollup configs that were missing it (graphql-devtools, memory-performance-profiler, render-waste-detector, security-audit-panel, visual-regression-monitor) — these plugins declared `types: "dist/index.d.ts"` in package.json but weren't generating the file
- **Promise error handling**: Added `.catch(resolve)` to `Promise.all` in screenshot-engine's `waitForImages` to prevent unhandled rejection

## Test plan
- [x] All 27 projects build successfully
- [x] All 27 project test suites pass
- [x] Verified .d.ts files are generated after rollup declaration fix (graphql-devtools, security-audit-panel)