### PR TITLE
fix: VirtualList shadowing bug, unhandled clipboard promises, perf fixes

### DIFF
--- a/packages/shared-components/src/components/VirtualList.tsx
+++ b/packages/shared-components/src/components/VirtualList.tsx
@@ -209,29 +209,29 @@ export function VirtualList<T>({
 
   // Render visible items
   const visibleItems = useMemo(() => {
-    const items: React.ReactNode[] = [];
+    const rendered: React.ReactNode[] = [];
 
     for (let i = visibleRange.startIndex; i <= visibleRange.endIndex; i++) {
-      const item = itemMetadata[i];
-      if (!item) continue;
+      const meta = itemMetadata[i];
+      if (!meta) continue;
 
-      const key = getItemKey ? getItemKey(items[i] as T, i) : i;
+      const key = getItemKey ? getItemKey(items[i], i) : i;
       const itemStyle: React.CSSProperties = {
         position: 'absolute',
-        top: item.offset,
+        top: meta.offset,
         left: 0,
         right: 0,
-        height: item.height,
+        height: meta.height,
       };
 
-      items.push(
+      rendered.push(
         <div key={key} style={itemStyle}>
-          {renderItem(items[i] as T, i, itemStyle)}
+          {renderItem(items[i], i, itemStyle)}
         </div>
       );
     }
 
-    return items;
+    return rendered;
   }, [visibleRange, itemMetadata, getItemKey, items, renderItem]);
 
   // Container styles

--- a/plugins/accessibility-devtools/src/components/ARIAValidator.tsx
+++ b/plugins/accessibility-devtools/src/components/ARIAValidator.tsx
@@ -12,6 +12,19 @@ import {
 } from 'lucide-react';
 import type { ARIAValidationIssue } from '../types';
 
+const VALID_ARIA_ROLES = new Set([
+  'alert', 'alertdialog', 'application', 'article', 'banner', 'button', 'cell', 'checkbox',
+  'columnheader', 'combobox', 'complementary', 'contentinfo', 'definition', 'dialog',
+  'directory', 'document', 'feed', 'figure', 'form', 'grid', 'gridcell', 'group',
+  'heading', 'img', 'link', 'list', 'listbox', 'listitem', 'log', 'main', 'marquee',
+  'math', 'menu', 'menubar', 'menuitem', 'menuitemcheckbox', 'menuitemradio', 'navigation',
+  'none', 'note', 'option', 'presentation', 'progressbar', 'radio', 'radiogroup',
+  'region', 'row', 'rowgroup', 'rowheader', 'scrollbar', 'search', 'searchbox',
+  'separator', 'slider', 'spinbutton', 'status', 'switch', 'tab', 'table', 'tablist',
+  'tabpanel', 'term', 'textbox', 'timer', 'toolbar', 'tooltip', 'tree', 'treegrid',
+  'treeitem'
+]);
+
 export interface ARIAValidatorProps {
   className?: string;
 }
@@ -30,19 +43,6 @@ export function ARIAValidator({ className }: ARIAValidatorProps) {
     // Get all elements with ARIA attributes or roles
     const elementsWithAria = document.querySelectorAll('[role], [aria-label], [aria-labelledby], [aria-describedby], [aria-expanded], [aria-checked], [aria-selected], [aria-hidden], [aria-live], [aria-atomic], [aria-relevant], [aria-busy], [aria-controls], [aria-owns], [aria-flowto], [aria-activedescendant], [aria-current], [aria-details], [aria-errormessage], [aria-haspopup], [aria-invalid], [aria-keyshortcuts], [aria-orientation], [aria-placeholder], [aria-pressed], [aria-readonly], [aria-required], [aria-roledescription], [aria-sort], [aria-valuemax], [aria-valuemin], [aria-valuenow], [aria-valuetext]');
 
-    const validRoles = new Set([
-      'alert', 'alertdialog', 'application', 'article', 'banner', 'button', 'cell', 'checkbox',
-      'columnheader', 'combobox', 'complementary', 'contentinfo', 'definition', 'dialog',
-      'directory', 'document', 'feed', 'figure', 'form', 'grid', 'gridcell', 'group',
-      'heading', 'img', 'link', 'list', 'listbox', 'listitem', 'log', 'main', 'marquee',
-      'math', 'menu', 'menubar', 'menuitem', 'menuitemcheckbox', 'menuitemradio', 'navigation',
-      'none', 'note', 'option', 'presentation', 'progressbar', 'radio', 'radiogroup',
-      'region', 'row', 'rowgroup', 'rowheader', 'scrollbar', 'search', 'searchbox',
-      'separator', 'slider', 'spinbutton', 'status', 'switch', 'tab', 'table', 'tablist',
-      'tabpanel', 'term', 'textbox', 'timer', 'toolbar', 'tooltip', 'tree', 'treegrid',
-      'treeitem'
-    ]);
-
     elementsWithAria.forEach((element) => {
       const selector = generateSelector(element);
       
@@ -51,7 +51,7 @@ export function ARIAValidator({ className }: ARIAValidatorProps) {
       if (role) {
         const roles = role.split(' ');
         roles.forEach(r => {
-          if (!validRoles.has(r.toLowerCase())) {
+          if (!VALID_ARIA_ROLES.has(r.toLowerCase())) {
             issues.push({
               element,
               selector,

--- a/plugins/auth-permissions-mock/src/components/AuthPermissionsMockPanel.tsx
+++ b/plugins/auth-permissions-mock/src/components/AuthPermissionsMockPanel.tsx
@@ -79,7 +79,7 @@ function AuthPermissionsMockPanelInner() {
   };
 
   const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
+    navigator.clipboard.writeText(text).catch(() => {});
   };
 
   const configMenuItems: ConfigMenuItem[] = [

--- a/plugins/bundle-impact-analyzer/src/components/tabs/ModulesTab.tsx
+++ b/plugins/bundle-impact-analyzer/src/components/tabs/ModulesTab.tsx
@@ -233,7 +233,7 @@ export function ModulesTab({ state, eventClient }: ModulesTabProps) {
                     </button>
                     <button
                       className="detail-action-btn"
-                      onClick={() => navigator.clipboard.writeText(module.path)}
+                      onClick={() => { navigator.clipboard.writeText(module.path).catch(() => {}); }}
                     >
                       <FileText size={14} />
                       Copy Path

--- a/plugins/design-system-inspector/src/components/tabs/TokensTab.tsx
+++ b/plugins/design-system-inspector/src/components/tabs/TokensTab.tsx
@@ -522,7 +522,7 @@ function TokenDetails({
   const [activeSection, setActiveSection] = useState<'overview' | 'usage' | 'issues'>('overview');
   
   const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
+    navigator.clipboard.writeText(text).catch(() => {});
   };
 
   const sections = [

--- a/plugins/error-boundary-visualizer/src/components/RecoveryStrategyEditor.tsx
+++ b/plugins/error-boundary-visualizer/src/components/RecoveryStrategyEditor.tsx
@@ -307,7 +307,7 @@ export const RecoveryStrategyEditor: React.FC = () => {
                   key={key}
                   style={secondaryButtonStyles}
                   onClick={() => {
-                    navigator.clipboard.writeText(template)
+                    navigator.clipboard.writeText(template).catch(() => {})
                   }}
                 >
                   Copy {key.charAt(0).toUpperCase() + key.slice(1)}

--- a/plugins/form-state-inspector/src/FormStateDevToolsPanel.tsx
+++ b/plugins/form-state-inspector/src/FormStateDevToolsPanel.tsx
@@ -82,7 +82,7 @@ const _getFieldStateIndicator = (field: FieldState): string => {
 };
 
 export function FormStateDevToolsPanel() {
-  const savedState = loadUIState();
+  const [savedState] = useState(loadUIState);
   
   const [forms, setForms] = useState<Record<string, FormState>>({});
   const [selectedFormId, _setSelectedFormId] = useState<string | null>(savedState.selectedFormId || null);

--- a/plugins/graphql-devtools/src/components/GraphQLDevToolsPanel.tsx
+++ b/plugins/graphql-devtools/src/components/GraphQLDevToolsPanel.tsx
@@ -49,7 +49,7 @@ export const GraphQLDevToolsPanel: React.FC = () => {
   };
 
   const handleCopyOperation = (operation: any) => {
-    navigator.clipboard.writeText(operation.query);
+    navigator.clipboard.writeText(operation.query).catch(() => {});
   };
 
   const handleReplayOperation = async (_operation: any) => {
@@ -212,7 +212,7 @@ export const GraphQLDevToolsPanel: React.FC = () => {
           onValidateQuery={handleValidateQuery}
           onResetBuilder={handleResetBuilder}
           onExecuteQuery={handleExecuteQuery}
-          onCopyQuery={(query) => navigator.clipboard.writeText(query)}
+          onCopyQuery={(query) => { navigator.clipboard.writeText(query).catch(() => {}); }}
           validationErrors={state.queryBuilder.validationErrors}
         />
       )

--- a/plugins/i18n-devtools/src/components/FormatPreview.tsx
+++ b/plugins/i18n-devtools/src/components/FormatPreview.tsx
@@ -635,7 +635,7 @@ export function FormatPreview({
             <button
               onClick={() => {
                 const results = examples.map(e => `${e.locale}: ${e.output}`).join('\n');
-                navigator.clipboard.writeText(results);
+                navigator.clipboard.writeText(results).catch(() => {});
               }}
               style={{
                 padding: '6px 12px',

--- a/plugins/i18n-devtools/src/components/I18nDevToolsPanel.tsx
+++ b/plugins/i18n-devtools/src/components/I18nDevToolsPanel.tsx
@@ -88,8 +88,8 @@ interface I18nDevToolsPanelProps {
 }
 
 function I18nDevToolsPanelInner() {
-  // Load saved UI state
-  const savedState = loadUIState();
+  // Load saved UI state (lazy initializer — runs only on first render)
+  const [savedState] = useState(loadUIState);
   
   // Core state
   const [i18nState, setI18nState] = useState<I18nState>({

--- a/plugins/i18n-devtools/src/components/MissingKeysPanel.tsx
+++ b/plugins/i18n-devtools/src/components/MissingKeysPanel.tsx
@@ -584,7 +584,7 @@ export function MissingKeysPanel({
             onClick={() => {
               // Export missing keys functionality would go here
               const exportData = JSON.stringify(missingKeys, null, 2);
-              navigator.clipboard.writeText(exportData);
+              navigator.clipboard.writeText(exportData).catch(() => {});
             }}
             style={{
               padding: '6px 12px',

--- a/plugins/logger-devtools/src/LoggerDevToolsPanel.tsx
+++ b/plugins/logger-devtools/src/LoggerDevToolsPanel.tsx
@@ -60,8 +60,8 @@ interface LoggerDevToolsPanelProps {
 }
 
 function LoggerDevToolsPanelInner() {
-  // Load saved UI state
-  const savedState = loadUIState();
+  // Load saved UI state (lazy initializer — runs only on first render)
+  const [savedState] = useState(loadUIState);
   
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const logsRef = useRef<LogEntry[]>([]);

--- a/plugins/router-devtools/src/components/NavigationTimeline.tsx
+++ b/plugins/router-devtools/src/components/NavigationTimeline.tsx
@@ -158,7 +158,7 @@ export function NavigationTimeline({
       icon: <Copy size={12} />,
       onClick: (row: NavigationHistoryEntry) => {
         const url = row.location.pathname + row.location.search + row.location.hash;
-        navigator.clipboard.writeText(url);
+        navigator.clipboard.writeText(url).catch(() => {});
       }
     },
     {

--- a/plugins/router-devtools/src/components/RouterDevToolsPanel.tsx
+++ b/plugins/router-devtools/src/components/RouterDevToolsPanel.tsx
@@ -78,8 +78,8 @@ interface RouterDevToolsPanelProps {
 }
 
 function RouterDevToolsPanelInner() {
-  // Load saved UI state
-  const savedState = loadUIState();
+  // Load saved UI state (lazy initializer — runs only on first render)
+  const [savedState] = useState(loadUIState);
 
   const [state, setState] = useState<RouterDevToolsState>({
     currentState: null,

--- a/plugins/stress-testing-devtools/src/components/TestRequestRunner.tsx
+++ b/plugins/stress-testing-devtools/src/components/TestRequestRunner.tsx
@@ -132,13 +132,13 @@ export const TestRequestRunner: React.FC<TestRequestRunnerProps> = ({
 
   const copyAsJson = () => {
     if (testResult) {
-      navigator.clipboard.writeText(JSON.stringify(testResult.response, null, 2))
+      navigator.clipboard.writeText(JSON.stringify(testResult.response, null, 2)).catch(() => {})
     }
   }
 
   const copyHeaders = () => {
     if (testResult) {
-      navigator.clipboard.writeText(JSON.stringify(testResult.headers, null, 2))
+      navigator.clipboard.writeText(JSON.stringify(testResult.headers, null, 2)).catch(() => {})
     }
   }
 

--- a/plugins/zustand-devtools/src/ZustandDevToolsPanel.tsx
+++ b/plugins/zustand-devtools/src/ZustandDevToolsPanel.tsx
@@ -59,8 +59,8 @@ interface ZustandDevToolsPanelProps {
 }
 
 function ZustandDevToolsPanelInner() {
-  // Load saved UI state
-  const savedState = loadUIState();
+  // Load saved UI state (lazy initializer — runs only on first render)
+  const [savedState] = useState(loadUIState);
   
   const [stores, setStores] = useState<Record<string, ZustandStoreState>>({});
   const [selectedStore, setSelectedStore] = useState<string | null>(savedState.selectedStore || null);


### PR DESCRIPTION
## Summary
- Fix **critical VirtualList correctness bug**: local `items` variable shadowed the `items` prop inside `useMemo`, causing `getItemKey` and `renderItem` to always receive `undefined` instead of actual item data
- Handle **unhandled clipboard promises** across 10 components in 7 plugins by adding `.catch(() => {})` — prevents unhandled promise rejections when clipboard permission is denied
- Use **lazy `useState` initializer** for `loadUIState()` in 5 plugin panels (zustand, form-state, logger, router, i18n) to avoid synchronous `localStorage.getItem()` + `JSON.parse()` on every render
- Move `VALID_ARIA_ROLES` Set to **module scope** in ARIAValidator to avoid rebuilding a 50+ entry Set on every validation call

## Files Changed (16)
- `packages/shared-components/src/components/VirtualList.tsx` — fix variable shadowing bug
- `plugins/accessibility-devtools/src/components/ARIAValidator.tsx` — hoist validRoles to module scope
- `plugins/auth-permissions-mock/src/components/AuthPermissionsMockPanel.tsx` — clipboard .catch()
- `plugins/bundle-impact-analyzer/src/components/tabs/ModulesTab.tsx` — clipboard .catch()
- `plugins/design-system-inspector/src/components/tabs/TokensTab.tsx` — clipboard .catch()
- `plugins/error-boundary-visualizer/src/components/RecoveryStrategyEditor.tsx` — clipboard .catch()
- `plugins/form-state-inspector/src/FormStateDevToolsPanel.tsx` — lazy loadUIState
- `plugins/graphql-devtools/src/components/GraphQLDevToolsPanel.tsx` — clipboard .catch() (2 sites)
- `plugins/i18n-devtools/src/components/FormatPreview.tsx` — clipboard .catch()
- `plugins/i18n-devtools/src/components/I18nDevToolsPanel.tsx` — lazy loadUIState
- `plugins/i18n-devtools/src/components/MissingKeysPanel.tsx` — clipboard .catch()
- `plugins/logger-devtools/src/LoggerDevToolsPanel.tsx` — lazy loadUIState
- `plugins/router-devtools/src/components/NavigationTimeline.tsx` — clipboard .catch()
- `plugins/router-devtools/src/components/RouterDevToolsPanel.tsx` — lazy loadUIState
- `plugins/stress-testing-devtools/src/components/TestRequestRunner.tsx` — clipboard .catch()
- `plugins/zustand-devtools/src/ZustandDevToolsPanel.tsx` — lazy loadUIState

## Test plan
- [x] TypeScript compilation passes for all 16 affected packages/plugins
- [x] shared-components tests pass (11/11)
- [x] form-state-inspector tests pass (79/79)
- [x] error-boundary-visualizer tests pass (158/158)

🤖 Generated with [Claude Code](https://claude.com/claude-code)