### PR TITLE
fix: subscription leak, cookie parsing, and CSV escaping bugs

### DIFF
--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Logger } from './logger';
 
 describe('Logger.cleanData', () => {
@@ -150,5 +150,65 @@ describe('Logger.cleanData', () => {
     expect(result.name).toBe('a');
     expect(result.ref.name).toBe('b');
     expect(result.ref.ref).toBe('[Circular]');
+  });
+});
+
+describe('Logger.exportLogs CSV escaping', () => {
+  let logger: Logger;
+
+  beforeEach(() => {
+    logger = Logger.getInstance();
+    logger.updateConfig({ output: { console: false }, level: 'trace' });
+    logger.clearLogs();
+    logger.clearMetrics();
+  });
+
+  afterEach(() => {
+    logger.disableConsoleCapture();
+    logger.destroy();
+    (Logger as any).instance = null;
+  });
+
+  it('escapes commas in CSV message field', () => {
+    logger.info('hello, world');
+    logger.forceFlush();
+
+    const csv = logger.exportLogs('csv');
+    const lines = csv.split('\n');
+
+    // Header + 1 data row
+    expect(lines.length).toBe(2);
+
+    // The message "hello, world" should be quoted
+    expect(lines[1]).toContain('"hello, world"');
+  });
+
+  it('escapes double quotes in CSV message field', () => {
+    logger.info('say "hi"');
+    logger.forceFlush();
+
+    const csv = logger.exportLogs('csv');
+    // "say ""hi""" - the message should have doubled internal quotes
+    expect(csv).toContain('"say ""hi"""');
+  });
+
+  it('escapes newlines in CSV message field', () => {
+    logger.info('line1\nline2');
+    logger.forceFlush();
+
+    const csv = logger.exportLogs('csv');
+    // The message should be wrapped in quotes due to newline
+    expect(csv).toContain('"line1\nline2"');
+  });
+
+  it('does not escape simple values', () => {
+    logger.info('simple');
+    logger.forceFlush();
+
+    const csv = logger.exportLogs('csv');
+    const lines = csv.split('\n');
+
+    // Simple value should not be quoted
+    expect(lines[1]).toContain(',simple,');
   });
 });

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -638,7 +638,7 @@ export class Logger {
           log.category || '',
           log.message,
           JSON.stringify(log.data || ''),
-        ]);
+        ].map(field => this.escapeCsvField(field)));
         return [headers, ...rows].map(row => row.join(',')).join('\n');
       }
       
@@ -652,6 +652,13 @@ export class Logger {
       default:
         return '';
     }
+  }
+
+  private escapeCsvField(value: string): string {
+    if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
+      return `"${value.replace(/"/g, '""')}"`;
+    }
+    return value;
   }
 
   // Event handling

--- a/plugins/browser-automation-test-recorder/src/core/parameterization/data-extractor.ts
+++ b/plugins/browser-automation-test-recorder/src/core/parameterization/data-extractor.ts
@@ -4,6 +4,7 @@
  */
 
 import type { RecordedEvent } from '../../types';
+import { escapeCsvField } from '@sucoza/devtools-common';
 
 export interface ExtractedParameter {
   id: string;
@@ -794,15 +795,10 @@ export class DataExtractor {
     if (dataSet.combinations.length === 0) return '';
 
     const paramNames = dataSet.parameters.map(p => p.name);
-    const header = paramNames.join(',');
-    
-    const rows = dataSet.combinations.map(combo => 
-      paramNames.map(name => {
-        const value = combo.values[name];
-        return typeof value === 'string' && value.includes(',') 
-          ? `"${value.replace(/"/g, '""')}"` 
-          : String(value);
-      }).join(',')
+    const header = paramNames.map(name => escapeCsvField(name)).join(',');
+
+    const rows = dataSet.combinations.map(combo =>
+      paramNames.map(name => escapeCsvField(String(combo.values[name] ?? ''))).join(',')
     );
 
     return [header, ...rows].join('\n');

--- a/plugins/logger-devtools/src/LoggerDevToolsPanel.tsx
+++ b/plugins/logger-devtools/src/LoggerDevToolsPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { loggingEventClient } from './loggingEventClient';
 import type { LogEntry, LogLevel, LoggerConfig, LogMetrics } from './loggingEventClient';
 import { Footer, type FooterStat, ConfigMenu, ThemeProvider, type ConfigMenuItem } from '@sucoza/shared-components';
+import { escapeCsvField } from '@sucoza/devtools-common';
 import '@sucoza/shared-components/dist/styles/theme.css';
 
 const LOG_COLORS: Record<LogLevel, string> = {
@@ -430,7 +431,7 @@ function LoggerDevToolsPanelInner() {
           log.category || '',
           log.message,
           JSON.stringify(log.data || ''),
-        ]);
+        ].map(field => escapeCsvField(field)));
         content = [headers, ...rows].map(row => row.join(',')).join('\n');
         mimeType = 'text/csv';
         extension = 'csv';

--- a/plugins/stress-testing-devtools/src/__tests__/stress-runner.test.ts
+++ b/plugins/stress-testing-devtools/src/__tests__/stress-runner.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { StressTestRunner } from '../stress-runner';
+
+describe('StressTestRunner', () => {
+  describe('XSRF cookie parsing', () => {
+    beforeEach(() => {
+      // Clear cookies and localStorage
+      Object.defineProperty(document, 'cookie', {
+        writable: true,
+        value: '',
+      });
+      vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+    });
+
+    test('should parse simple XSRF cookie value', () => {
+      Object.defineProperty(document, 'cookie', {
+        writable: true,
+        value: 'XSRF-TOKEN-WEBAPI=abc123',
+      });
+
+      const runner = new StressTestRunner(vi.fn());
+      const authContext = (runner as any).authContext;
+      expect(authContext.xsrfToken).toBe('abc123');
+    });
+
+    test('should preserve equals signs in base64 cookie value', () => {
+      Object.defineProperty(document, 'cookie', {
+        writable: true,
+        value: 'XSRF-TOKEN-WEBAPI=dGVzdA==',
+      });
+
+      const runner = new StressTestRunner(vi.fn());
+      const authContext = (runner as any).authContext;
+      // Previously would have returned just "dGVzdA" (truncated at first =)
+      expect(authContext.xsrfToken).toBe('dGVzdA==');
+    });
+
+    test('should handle cookie value with multiple equals signs', () => {
+      Object.defineProperty(document, 'cookie', {
+        writable: true,
+        value: 'other=x; XSRF-TOKEN-WEBAPI=key=value=extra; session=y',
+      });
+
+      const runner = new StressTestRunner(vi.fn());
+      const authContext = (runner as any).authContext;
+      expect(authContext.xsrfToken).toBe('key=value=extra');
+    });
+
+    test('should handle missing XSRF cookie', () => {
+      Object.defineProperty(document, 'cookie', {
+        writable: true,
+        value: 'other=value; session=abc',
+      });
+
+      const runner = new StressTestRunner(vi.fn());
+      const authContext = (runner as any).authContext;
+      expect(authContext.xsrfToken).toBeNull();
+    });
+
+    test('should handle empty cookie value', () => {
+      Object.defineProperty(document, 'cookie', {
+        writable: true,
+        value: 'XSRF-TOKEN-WEBAPI=',
+      });
+
+      const runner = new StressTestRunner(vi.fn());
+      const authContext = (runner as any).authContext;
+      expect(authContext.xsrfToken).toBe('');
+    });
+  });
+});

--- a/plugins/stress-testing-devtools/src/stress-runner.ts
+++ b/plugins/stress-testing-devtools/src/stress-runner.ts
@@ -24,7 +24,9 @@ export class StressTestRunner {
       .find(row => row.startsWith('XSRF-TOKEN-WEBAPI='))
     
     if (xsrfCookie) {
-      this.authContext.xsrfToken = xsrfCookie.split('=')[1]
+      // Use substring to preserve '=' chars in the value (e.g. base64 tokens)
+      const eqIndex = xsrfCookie.indexOf('=')
+      this.authContext.xsrfToken = eqIndex >= 0 ? xsrfCookie.substring(eqIndex + 1) : null
     }
   }
 

--- a/plugins/visual-regression-monitor/src/hooks/useVisualDiff.ts
+++ b/plugins/visual-regression-monitor/src/hooks/useVisualDiff.ts
@@ -2,6 +2,7 @@ import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import type { VisualDiff, DiffRequest, Screenshot } from '../types';
 import { createVisualRegressionDevToolsClient } from '../core/devtools-client';
 import { getDiffAlgorithm } from '../core/diff-algorithm';
+import { escapeCsvField } from '@sucoza/devtools-common';
 
 /**
  * Hook for managing visual diffs and comparisons
@@ -313,7 +314,7 @@ export function useVisualDiff() {
         const headers = Object.keys(results[0] || {});
         const csvContent = [
           headers.join(','),
-          ...results.map(row => headers.map(header => row[header as keyof typeof row]).join(','))
+          ...results.map(row => headers.map(header => escapeCsvField(String(row[header as keyof typeof row] ?? ''))).join(','))
         ].join('\n');
 
         const blob = new Blob([csvContent], { type: 'text/csv' });

--- a/plugins/zustand-devtools/src/__tests__/zustandDevtoolsIntegration.test.ts
+++ b/plugins/zustand-devtools/src/__tests__/zustandDevtoolsIntegration.test.ts
@@ -5,7 +5,9 @@ import { zustandEventClient } from '../zustandEventClient';
 
 describe('Zustand DevTools Integration - State Restoration', () => {
   beforeEach(() => {
-    // Clear any registered stores before each test
+    // Clean up old subscriptions before clearing
+    zustandRegistry['storeSubscriptions'].forEach((unsub: () => void) => unsub());
+    zustandRegistry['storeSubscriptions'].clear();
     zustandRegistry['stores'].clear();
     zustandRegistry['storeStates'].clear();
     zustandRegistry['actionHistory'] = [];
@@ -377,6 +379,66 @@ describe('Zustand DevTools Integration - State Restoration', () => {
     test('should get action history', () => {
       const history = zustandRegistry.getActionHistory();
       expect(Array.isArray(history)).toBe(true);
+    });
+  });
+
+  describe('Subscription Cleanup on Re-registration', () => {
+    test('should clean up old subscription when re-registering same store name', () => {
+      interface TestStore {
+        value: number;
+        setValue: (v: number) => void;
+      }
+
+      const useStore = create<TestStore>((set) => ({
+        value: 0,
+        setValue: (v: number) => set({ value: v }),
+      }));
+
+      // First registration
+      zustandRegistry.registerStore('myStore', useStore as any);
+
+      // Re-register the same store name (simulating hot reload or re-mount)
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      zustandRegistry.registerStore('myStore', useStore as any);
+      consoleSpy.mockRestore();
+
+      // Clear history to count only new actions
+      zustandRegistry.clearActionHistory();
+
+      // Trigger a state change
+      useStore.getState().setValue(42);
+
+      // Should only have ONE action entry (not two from duplicate subscriptions)
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          const history = zustandRegistry.getActionHistory();
+          const storeActions = history.filter(h => h.storeName === 'myStore');
+          expect(storeActions).toHaveLength(1);
+          resolve();
+        }, 20);
+      });
+    });
+
+    test('should unsubscribe old store subscription before overwriting', () => {
+      interface TestStore {
+        count: number;
+      }
+
+      const useStore1 = create<TestStore>(() => ({ count: 1 }));
+      const useStore2 = create<TestStore>(() => ({ count: 2 }));
+
+      // Register first store
+      zustandRegistry.registerStore('shared', useStore1 as any);
+
+      // Re-register with a different store instance
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      zustandRegistry.registerStore('shared', useStore2 as any);
+      consoleSpy.mockRestore();
+
+      // The registry should track the new store's state
+      const stores = zustandRegistry.getStores();
+      const shared = stores.find(s => s.name === 'shared');
+      expect(shared?.state).toMatchObject({ count: 2 });
     });
   });
 });

--- a/plugins/zustand-devtools/src/zustandDevtoolsIntegration.ts
+++ b/plugins/zustand-devtools/src/zustandDevtoolsIntegration.ts
@@ -104,6 +104,9 @@ class ZustandStoreRegistry {
   registerStore(name: string, store: AnyStore) {
     if (this.stores.has(name)) {
       console.warn(`Store "${name}" is already registered. Overwriting.`);
+      // Clean up old subscription to prevent leak
+      const oldUnsub = this.storeSubscriptions.get(name);
+      if (oldUnsub) oldUnsub();
     }
 
     this.stores.set(name, store);


### PR DESCRIPTION
## Summary
- Fix Zustand `registerStore` leaking old subscriptions when re-registering the same store name (memory leak on hot reload / re-mount)
- Fix XSRF cookie value truncation when value contains `=` characters (e.g. base64 tokens)
- Add CSV field escaping to Logger.exportLogs, LoggerDevToolsPanel, useVisualDiff export, and DataExtractor export
- Add unit tests for subscription cleanup, cookie parsing edge cases, and CSV escaping

## Test plan
- [x] Logger CSV escaping tests pass (`npx nx run logger:test`)
- [x] Zustand subscription cleanup tests pass (`npx nx run zustand-devtools:test`)
- [x] Stress runner cookie parsing tests pass (`npx nx run stress-testing-devtools:test`)
- [x] Typecheck passes for all modified projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)