### PR TITLE
fix: formatBytes bounds, running average, interval leak, and division-by-zero

### DIFF
--- a/plugins/browser-automation-test-recorder/src/__tests__/unit/utils/formatFileSize.test.ts
+++ b/plugins/browser-automation-test-recorder/src/__tests__/unit/utils/formatFileSize.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'vitest';
+import { formatFileSize } from '../../../utils/index';
+
+describe('formatFileSize', () => {
+  test('returns "0 B" for zero', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+  });
+
+  test('formats byte values correctly', () => {
+    expect(formatFileSize(500)).toBe('500 B');
+    expect(formatFileSize(1024)).toBe('1 KB');
+    expect(formatFileSize(1048576)).toBe('1 MB');
+  });
+
+  test('handles fractional byte values (< 1) without crashing', () => {
+    const result = formatFileSize(0.5);
+    expect(result).toContain('B');
+    expect(result).not.toContain('undefined');
+    expect(result).not.toContain('NaN');
+  });
+
+  test('handles very large values beyond GB', () => {
+    const result = formatFileSize(2 * 1024 * 1024 * 1024 * 1024);
+    expect(result).toContain('GB');
+    expect(result).not.toContain('undefined');
+  });
+});

--- a/plugins/browser-automation-test-recorder/src/utils/index.ts
+++ b/plugins/browser-automation-test-recorder/src/utils/index.ts
@@ -232,8 +232,8 @@ export function formatFileSize(bytes: number): string {
   
   const k = 1024;
   const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  
+  const i = Math.min(sizes.length - 1, Math.max(0, Math.floor(Math.log(bytes) / Math.log(k))));
+
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
 }
 

--- a/plugins/bundle-impact-analyzer/src/core/devtools-store.test.ts
+++ b/plugins/bundle-impact-analyzer/src/core/devtools-store.test.ts
@@ -86,6 +86,32 @@ describe('BundleAnalyzerStore – interval and division-by-zero fixes', () => {
     expect(progressAfterMoreTime).toBe(progressAtStop);
   });
 
+  // --- Double-start guard: calling startAnalysis twice should not leak intervals ---
+
+  it('calling startAnalysis twice clears the previous interval', () => {
+    const { startAnalysis } = useBundleAnalyzerStore.getState();
+
+    // Start first analysis
+    startAnalysis();
+    const firstJobCount = useBundleAnalyzerStore.getState().jobs.length;
+
+    // Advance a couple ticks
+    vi.advanceTimersByTime(400);
+
+    // Start second analysis without stopping the first
+    startAnalysis();
+
+    // Advance enough time for the first analysis to have completed
+    // if it were still running (10 ticks * 200ms = 2000ms + buffer)
+    vi.advanceTimersByTime(2200);
+
+    const state = useBundleAnalyzerStore.getState();
+    // The second analysis should have completed normally
+    expect(state.isAnalyzing).toBe(false);
+    // We should have 2 jobs total (first was abandoned, second completed)
+    expect(state.jobs.length).toBe(firstJobCount + 1);
+  });
+
   // --- Division by zero guard: empty exports array ---
 
   it('analyzeImportImpact does not produce Infinity for module with empty exports', () => {

--- a/plugins/bundle-impact-analyzer/src/core/devtools-store.ts
+++ b/plugins/bundle-impact-analyzer/src/core/devtools-store.ts
@@ -131,12 +131,18 @@ export const useBundleAnalyzerStore = create<BundleAnalyzerStore>()(
      * Core analysis methods
      */
     startAnalysis: () => {
+      // Clear any existing analysis interval to prevent leaks
+      if (analysisInterval) {
+        clearInterval(analysisInterval);
+        analysisInterval = null;
+      }
+
       const jobId = get().startJob({
         type: 'full-analysis',
         status: 'running',
         progress: 0,
       });
-      
+
       set(() => ({
         isAnalyzing: true,
         lastAnalysisTime: Date.now(),

--- a/plugins/bundle-impact-analyzer/src/core/interceptor.ts
+++ b/plugins/bundle-impact-analyzer/src/core/interceptor.ts
@@ -289,7 +289,7 @@ export class BundleInterceptor {
     try {
       const response = await fetch(url, { method: 'HEAD' });
       const contentLength = response.headers.get('Content-Length');
-      return contentLength ? parseInt(contentLength, 10) : 0;
+      return contentLength ? (parseInt(contentLength, 10) || 0) : 0;
     } catch {
       return 0;
     }

--- a/plugins/design-system-inspector/src/core/devtools-store.ts
+++ b/plugins/design-system-inspector/src/core/devtools-store.ts
@@ -455,7 +455,7 @@ class DesignSystemDevToolsStore {
         const totalCount = existing.values.reduce((sum: number, v: any) => sum + v.count, 0);
         existing.values = existing.values.map((v: any) => ({
           ...v,
-          percentage: (v.count / totalCount) * 100,
+          percentage: totalCount > 0 ? (v.count / totalCount) * 100 : 0,
         }));
       } else {
         propsMap.set(newProp.name, { ...newProp, values: newProp.values.map((v: any) => ({ ...v })) });

--- a/plugins/memory-performance-profiler/src/__tests__/memory-utils.test.ts
+++ b/plugins/memory-performance-profiler/src/__tests__/memory-utils.test.ts
@@ -1,0 +1,159 @@
+import { describe, test, expect } from 'vitest';
+import {
+  formatBytes,
+  formatBytesPerSecond,
+  calculateMemoryUtilization,
+  calculateGrowthRate,
+  generateMemoryStats,
+} from '../utils/memory-utils';
+
+describe('formatBytes', () => {
+  test('returns "0 B" for zero', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  test('formats bytes correctly', () => {
+    expect(formatBytes(500)).toBe('500 B');
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(1048576)).toBe('1 MB');
+    expect(formatBytes(1073741824)).toBe('1 GB');
+  });
+
+  test('handles fractional byte values (< 1) without crashing', () => {
+    // Previously, Math.log(0.5)/Math.log(1024) produced a negative index
+    // causing sizes[i] to be undefined and returning "NaN undefined"
+    const result = formatBytes(0.5);
+    expect(result).toContain('B');
+    expect(result).not.toContain('undefined');
+    expect(result).not.toContain('NaN');
+  });
+
+  test('handles very small fractional values', () => {
+    const result = formatBytes(0.001);
+    expect(result).toContain('B');
+    expect(result).not.toContain('undefined');
+  });
+
+  test('handles very large values beyond TB', () => {
+    // 2 PB - should clamp to TB (last in sizes array)
+    const result = formatBytes(2 * 1024 * 1024 * 1024 * 1024 * 1024);
+    expect(result).toContain('TB');
+    expect(result).not.toContain('undefined');
+  });
+
+  test('respects decimals parameter', () => {
+    expect(formatBytes(1536, 0)).toBe('2 KB');
+    expect(formatBytes(1536, 1)).toBe('1.5 KB');
+    expect(formatBytes(1536, 3)).toBe('1.5 KB');
+  });
+});
+
+describe('formatBytesPerSecond', () => {
+  test('returns "0 B/s" for zero', () => {
+    expect(formatBytesPerSecond(0)).toBe('0 B/s');
+  });
+
+  test('formats positive rates correctly', () => {
+    expect(formatBytesPerSecond(1024)).toBe('1 KB/s');
+    expect(formatBytesPerSecond(1048576)).toBe('1 MB/s');
+  });
+
+  test('handles negative rates', () => {
+    const result = formatBytesPerSecond(-1024);
+    expect(result).toBe('-1 KB/s');
+  });
+
+  test('handles very small absolute values (< 1) without crashing', () => {
+    // Previously produced negative index causing "NaN undefined"
+    const result = formatBytesPerSecond(0.5);
+    expect(result).toContain('B/s');
+    expect(result).not.toContain('undefined');
+    expect(result).not.toContain('NaN');
+  });
+
+  test('handles very small negative values without crashing', () => {
+    const result = formatBytesPerSecond(-0.001);
+    expect(result).toContain('B/s');
+    expect(result).not.toContain('undefined');
+  });
+
+  test('handles very large values beyond GB', () => {
+    const result = formatBytesPerSecond(2 * 1024 * 1024 * 1024 * 1024);
+    expect(result).toContain('GB/s');
+    expect(result).not.toContain('undefined');
+  });
+});
+
+describe('calculateMemoryUtilization', () => {
+  test('returns 0 when limit is 0', () => {
+    expect(calculateMemoryUtilization(100, 0)).toBe(0);
+  });
+
+  test('caps at 1 when used exceeds limit', () => {
+    expect(calculateMemoryUtilization(200, 100)).toBe(1);
+  });
+
+  test('calculates ratio correctly', () => {
+    expect(calculateMemoryUtilization(50, 100)).toBe(0.5);
+  });
+});
+
+describe('calculateGrowthRate', () => {
+  test('returns 0 for empty timeline', () => {
+    expect(calculateGrowthRate([])).toBe(0);
+  });
+
+  test('returns 0 for single-point timeline', () => {
+    expect(calculateGrowthRate([{ timestamp: 1000, usedMemory: 100 }])).toBe(0);
+  });
+
+  test('calculates positive growth rate', () => {
+    const timeline = [
+      { timestamp: 0, usedMemory: 1000 },
+      { timestamp: 1000, usedMemory: 2000 },
+    ];
+    expect(calculateGrowthRate(timeline)).toBe(1000); // 1000 bytes per second
+  });
+
+  test('returns 0 when timestamps are identical', () => {
+    const timeline = [
+      { timestamp: 1000, usedMemory: 100 },
+      { timestamp: 1000, usedMemory: 200 },
+    ];
+    expect(calculateGrowthRate(timeline)).toBe(0);
+  });
+});
+
+describe('generateMemoryStats', () => {
+  test('returns zeros for empty timeline', () => {
+    const stats = generateMemoryStats([]);
+    expect(stats.current).toBe(0);
+    expect(stats.min).toBe(0);
+    expect(stats.max).toBe(0);
+    expect(stats.average).toBe(0);
+    expect(stats.median).toBe(0);
+    expect(stats.standardDeviation).toBe(0);
+    expect(stats.duration).toBe(0);
+  });
+
+  test('calculates median for odd-length timeline', () => {
+    const timeline = [
+      { timestamp: 0, usedMemory: 100 },
+      { timestamp: 1000, usedMemory: 200 },
+      { timestamp: 2000, usedMemory: 300 },
+    ];
+    const stats = generateMemoryStats(timeline);
+    expect(stats.median).toBe(200);
+  });
+
+  test('calculates median for even-length timeline', () => {
+    const timeline = [
+      { timestamp: 0, usedMemory: 100 },
+      { timestamp: 1000, usedMemory: 200 },
+      { timestamp: 2000, usedMemory: 300 },
+      { timestamp: 3000, usedMemory: 400 },
+    ];
+    const stats = generateMemoryStats(timeline);
+    expect(stats.median).toBe(250);
+  });
+});

--- a/plugins/memory-performance-profiler/src/utils/memory-utils.ts
+++ b/plugins/memory-performance-profiler/src/utils/memory-utils.ts
@@ -12,7 +12,7 @@ export function formatBytes(bytes: number, decimals: number = 2): string {
   const dm = decimals < 0 ? 0 : decimals;
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
 
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const i = Math.min(sizes.length - 1, Math.max(0, Math.floor(Math.log(bytes) / Math.log(k))));
 
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }
@@ -27,7 +27,7 @@ export function formatBytesPerSecond(bytesPerSecond: number, decimals: number = 
   const dm = decimals < 0 ? 0 : decimals;
   const sizes = ['B/s', 'KB/s', 'MB/s', 'GB/s'];
 
-  const i = Math.floor(Math.log(Math.abs(bytesPerSecond)) / Math.log(k));
+  const i = Math.min(sizes.length - 1, Math.max(0, Math.floor(Math.log(Math.abs(bytesPerSecond)) / Math.log(k))));
 
   return parseFloat((bytesPerSecond / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }

--- a/plugins/visual-regression-monitor/src/utils/__tests__/formatFileSize.test.ts
+++ b/plugins/visual-regression-monitor/src/utils/__tests__/formatFileSize.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from 'vitest';
+import { formatFileSize } from '../index';
+
+describe('formatFileSize', () => {
+  test('returns "0 B" for zero', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+  });
+
+  test('formats byte values correctly', () => {
+    expect(formatFileSize(500)).toBe('500 B');
+    expect(formatFileSize(1024)).toBe('1 KB');
+    expect(formatFileSize(1048576)).toBe('1 MB');
+  });
+
+  test('handles fractional byte values (< 1) without crashing', () => {
+    // Previously Math.log(0.5)/Math.log(1024) produced negative index
+    // causing sizes[i] to be undefined
+    const result = formatFileSize(0.5);
+    expect(result).toContain('B');
+    expect(result).not.toContain('undefined');
+    expect(result).not.toContain('NaN');
+  });
+
+  test('handles very large values beyond GB', () => {
+    // Should clamp to GB (last in sizes array)
+    const result = formatFileSize(2 * 1024 * 1024 * 1024 * 1024);
+    expect(result).toContain('GB');
+    expect(result).not.toContain('undefined');
+  });
+});

--- a/plugins/visual-regression-monitor/src/utils/index.ts
+++ b/plugins/visual-regression-monitor/src/utils/index.ts
@@ -27,8 +27,8 @@ export function formatFileSize(bytes: number): string {
   
   const k = 1024;
   const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  
+  const i = Math.min(sizes.length - 1, Math.max(0, Math.floor(Math.log(bytes) / Math.log(k))));
+
   return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
 }
 

--- a/plugins/websocket-signalr-devtools/src/core/__tests__/signalr-interceptor.test.ts
+++ b/plugins/websocket-signalr-devtools/src/core/__tests__/signalr-interceptor.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { SignalRInterceptor } from '../signalr-interceptor';
+
+describe('SignalRInterceptor', () => {
+  let interceptor: SignalRInterceptor;
+
+  beforeEach(() => {
+    interceptor = new SignalRInterceptor();
+  });
+
+  describe('updateHubMethodStats running average', () => {
+    test('should compute correct incremental average over multiple invocations', () => {
+      // Set up a connection so updateHubMethodStats can find it
+      const connectionId = 'test-conn';
+      (interceptor as any).connectionData.set(connectionId, {
+        id: connectionId,
+        hubMethods: new Map(),
+        errors: [],
+        messages: [],
+      });
+
+      const updateStats = (methodName: string, startTime: number, endTime?: number) => {
+        (interceptor as any).updateHubMethodStats(connectionId, methodName, startTime, endTime);
+      };
+
+      // Three calls with execution times of 100, 200, 300
+      // Correct average should be (100 + 200 + 300) / 3 = 200
+      updateStats('testMethod', 0, 100);    // exec = 100
+      updateStats('testMethod', 0, 200);    // exec = 200
+      updateStats('testMethod', 0, 300);    // exec = 300
+
+      const connection = (interceptor as any).connectionData.get(connectionId);
+      const method = connection.hubMethods.get('testMethod');
+
+      expect(method.invocationCount).toBe(3);
+      // With old formula (avg + new) / 2: after 3 calls would give 225, not 200
+      // With correct incremental mean: avg + (new - avg) / count = 200
+      expect(method.averageExecutionTime).toBeCloseTo(200, 5);
+    });
+
+    test('should handle single invocation', () => {
+      const connectionId = 'test-conn';
+      (interceptor as any).connectionData.set(connectionId, {
+        id: connectionId,
+        hubMethods: new Map(),
+        errors: [],
+        messages: [],
+      });
+
+      (interceptor as any).updateHubMethodStats(connectionId, 'single', 0, 150);
+
+      const connection = (interceptor as any).connectionData.get(connectionId);
+      const method = connection.hubMethods.get('single');
+
+      expect(method.invocationCount).toBe(1);
+      expect(method.averageExecutionTime).toBe(150);
+    });
+
+    test('should not update average when endTime is not provided', () => {
+      const connectionId = 'test-conn';
+      (interceptor as any).connectionData.set(connectionId, {
+        id: connectionId,
+        hubMethods: new Map(),
+        errors: [],
+        messages: [],
+      });
+
+      (interceptor as any).updateHubMethodStats(connectionId, 'noEnd', 100);
+
+      const connection = (interceptor as any).connectionData.get(connectionId);
+      const method = connection.hubMethods.get('noEnd');
+
+      expect(method.invocationCount).toBe(1);
+      expect(method.averageExecutionTime).toBe(0);
+    });
+
+    test('should handle non-existent connection gracefully', () => {
+      // Should not throw
+      expect(() => {
+        (interceptor as any).updateHubMethodStats('non-existent', 'method', 0, 100);
+      }).not.toThrow();
+    });
+
+    test('should converge to true average over many invocations', () => {
+      const connectionId = 'test-conn';
+      (interceptor as any).connectionData.set(connectionId, {
+        id: connectionId,
+        hubMethods: new Map(),
+        errors: [],
+        messages: [],
+      });
+
+      // 10 invocations, each 50ms
+      for (let i = 0; i < 10; i++) {
+        (interceptor as any).updateHubMethodStats(connectionId, 'uniform', 0, 50);
+      }
+
+      const connection = (interceptor as any).connectionData.get(connectionId);
+      const method = connection.hubMethods.get('uniform');
+
+      expect(method.invocationCount).toBe(10);
+      expect(method.averageExecutionTime).toBeCloseTo(50, 5);
+    });
+  });
+});

--- a/plugins/websocket-signalr-devtools/src/core/signalr-interceptor.ts
+++ b/plugins/websocket-signalr-devtools/src/core/signalr-interceptor.ts
@@ -480,7 +480,7 @@ export class SignalRInterceptor extends EventEmitter<{
 
     if (endTime) {
       const executionTime = endTime - startTime;
-      method.averageExecutionTime = (method.averageExecutionTime + executionTime) / 2;
+      method.averageExecutionTime += (executionTime - method.averageExecutionTime) / method.invocationCount;
     }
 
     this.emit('hubMethodCalled', { connectionId, method });


### PR DESCRIPTION
## Summary
- **formatBytes/formatFileSize index out of bounds**: Fixed in 4 files (`memory-utils.ts`, `browser-automation-test-recorder/utils`, `visual-regression-monitor/utils`). `Math.log(x)/Math.log(1024)` for fractional values (< 1 byte) or very large values produced an index outside `sizes[]` array bounds, returning `"NaN undefined"`. Added `Math.min(sizes.length - 1, Math.max(0, ...))` clamping.
- **SignalR running average**: Fixed incorrect `(avg + new) / 2` formula in `signalr-interceptor.ts` `updateHubMethodStats()`. This heavily biased toward recent values. Replaced with proper incremental mean: `avg += (new - avg) / count`.
- **Bundle analyzer double-start interval leak**: `startAnalysis()` in `bundle-impact-analyzer/devtools-store.ts` overwrote `analysisInterval` without clearing the previous one. Added guard to clear existing interval before starting new analysis.
- **parseInt NaN from Content-Length**: `getBundleSize()` in `bundle-impact-analyzer/interceptor.ts` could return NaN from `parseInt()` on malformed Content-Length headers. Added `|| 0` fallback.
- **Division by zero in mergeProps**: `DesignSystemDevToolsStore.mergeProps()` divided by `totalCount` without checking for zero. Added `totalCount > 0` guard.

## Test plan
- [x] New test file: `memory-performance-profiler/__tests__/memory-utils.test.ts` — tests formatBytes/formatBytesPerSecond with fractional, zero, negative, and large values
- [x] New test file: `websocket-signalr-devtools/core/__tests__/signalr-interceptor.test.ts` — tests incremental mean converges to true average over multiple invocations
- [x] New test file: `visual-regression-monitor/utils/__tests__/formatFileSize.test.ts` — tests formatFileSize edge cases
- [x] New test file: `browser-automation-test-recorder/__tests__/unit/utils/formatFileSize.test.ts` — tests formatFileSize edge cases
- [x] Added test to `bundle-impact-analyzer/devtools-store.test.ts` — tests double-start clears previous interval
- [x] All 27 projects pass `nx run-many --target=test --all`
- [x] All projects pass `nx run-many --target=typecheck --all`